### PR TITLE
Position Start block correctly after resizing

### DIFF
--- a/game/static/game/js/blocklyCustomisations.js
+++ b/game/static/game/js/blocklyCustomisations.js
@@ -177,8 +177,10 @@ ocargo.BlocklyCustomisations = function() {
 		};
 
 		this.bringStartBlockFromUnderFlyout = function() {
-		    Blockly.mainWorkspace.scrollbar.hScroll.set(blocklyDiv.offsetWidth - 455);
-		    Blockly.mainWorkspace.scrollbar.vScroll.set(blocklyDiv.offsetHeight - 15);
+			var distanceFromToolboxDiv = 455;
+			var distanceFromTopMargin = 15;
+            Blockly.mainWorkspace.scrollbar.hScroll.set(blocklyDiv.offsetWidth - distanceFromToolboxDiv);
+            Blockly.mainWorkspace.scrollbar.vScroll.set(blocklyDiv.offsetHeight - distanceFromTopMargin);
 		};
 	};
 


### PR DESCRIPTION
The bug was just a typo, choosing the right offset to apply to the vertical scrollbar.
I tried getting the offsets programatically (to remove the constants) but I could not find an easy way of doing it; suggestions welcome! :)

Fixes #547 
