### PR TITLE
Allow double-clicking on a workspace row to load that workspace

### DIFF
--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -574,7 +574,7 @@ ocargo.Game.prototype.setupTabs = function() {
             });
         });
 
-        $('#loadWorkspace').click(function() {
+        function loadSelectedWorkspace() {
             if (selectedWorkspace) {
 
                 // Blockly or Python tab must be selected before domToWorkspace is called
@@ -604,7 +604,9 @@ ocargo.Game.prototype.setupTabs = function() {
                 });
 
             }
-        });
+        }
+
+        $('#loadWorkspace').click(loadSelectedWorkspace);
 
         $('#deleteWorkspace').click(function() {
             if (selectedWorkspace) {
@@ -624,13 +626,17 @@ ocargo.Game.prototype.setupTabs = function() {
             populateTable("loadWorkspaceTable", workspaces);
 
             // Add click listeners to all rows
-            $('#loadWorkspaceTable tr').on('click', function(event) {
-                $('#loadWorkspaceTable tr').attr('selected', false);
+            var rows = $('#loadWorkspaceTable tr');
+            rows.on('click', function() {
+                rows.attr('selected', false);
                 $(this).attr('selected', true);
                 selectedWorkspace = $(this).attr('value');
                 $('#loadWorkspace').removeAttr('disabled');
                 $('#deleteWorkspace').removeAttr('disabled');
             });
+
+            // Add double click listener to load the workspace selected by the first click
+            rows.on('dblclick', loadSelectedWorkspace);
 
             var empty = workspaces.length === 0;
             $('#load_pane .scrolling-table-wrapper').css('display',  empty ? 'none' : 'block');


### PR DESCRIPTION
For #630. Tested on all the desktop browsers I have (Chrome, Firefox, Safari). I did briefly try it on my phone, but I think pretty much every mobile browser uses double-tap to zoom. I reckon this is only really a feature we want for desktop users anyway, so I don't think that's a problem. It's probably worth quickly checking whether this is OK on the iPad before merging though.
