### PR TITLE
Reset game every time we stop the animation

### DIFF
--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -519,6 +519,7 @@ ocargo.Game.prototype.onPauseControls = function() {
 };
 
 ocargo.Game.prototype.onStopControls = function() {
+    this.reset();
     this.allowCodeChanges();
 
     // TODO make this hidden unless blocks are clear or something...
@@ -652,7 +653,6 @@ ocargo.Game.prototype._setupPlayTab = function () {
 
 ocargo.Game.prototype._setupStopTab = function () {
     this.tabs.stop.setOnChange(function () {
-        this.reset();
         this.onStopControls();
 
         this.selectPreviousTab();


### PR DESCRIPTION
Noticed on the traffic lights behaviour: we were not resetting the game after every attempt.
The traffic lights were stale after the first try, and did not move any more.

Now, "reset" is called within "onStopControls".
This ensures the game goes back to the initial state after every attempt.

I have tested it quickly in a couple of levels.
Let me know if this could be an issue.