### PR TITLE
Avoid blank animation steps

### DIFF
--- a/game/static/game/js/model.js
+++ b/game/static/game/js/model.js
@@ -322,8 +322,6 @@ ocargo.Model.prototype.moveVan = function(nextNode, action) {
 
         model.incrementMovementTime();
 
-        model.incrementTime();
-
         ocargo.animation.appendAnimation({
             type: 'popup',
             popupType: 'FAIL',


### PR DESCRIPTION
The animation loses a blank step (introduced by calling incrementTime twice: once within incrementMovementTime and another one explicitly).
That blank step made the Step functionality appear as broken when the van crashes (as it required 2 clicks for the popup to appear).

The blank step has been removed, which means all animations in which the van crashes will lose 1 wait time (~ 500ms).
Should I introduce the wait as an animation, or it's ok to lose that step?

Fixes #614 