### PR TITLE
Cannot load incompatible workspace - wip

### DIFF
--- a/game/migrations/0057_workspace_language_enabled.py
+++ b/game/migrations/0057_workspace_language_enabled.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('game', '0056_mark_all_attempts_as_best'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='workspace',
+            name='blockly_enabled',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='workspace',
+            name='python_enabled',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/game/models.py
+++ b/game/models.py
@@ -166,6 +166,8 @@ class Workspace(models.Model):
     owner = models.ForeignKey(UserProfile, related_name='workspaces', blank=True, null=True)
     contents = models.TextField(default="")
     python_contents = models.TextField(default="")
+    blockly_enabled = models.BooleanField(default=False)
+    python_enabled = models.BooleanField(default=False)
 
     def __unicode__(self):
         return str(self.name)

--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -861,7 +861,9 @@ ocargo.Game.prototype._setupSaveTab = function () {
             var workspace = {
                 name: newName,
                 contents: ocargo.blocklyControl.serialize(),
-                python_contents: ocargo.pythonControl.getCode()
+                python_contents: ocargo.pythonControl.getCode(),
+                blockly_enabled: BLOCKLY_ENABLED,
+                python_enabled: PYTHON_ENABLED
             };
 
             this.saving.saveWorkspace(workspace, existingID, function (err, workspaces) {
@@ -976,18 +978,16 @@ ocargo.Game.prototype._populateTable = function (tableName, workspaces) {
 
     // Order them alphabetically
     sortedWorkspaces = ocargo.utils.sortObjects(workspaces, 'name');
-
     workspaces = sortedWorkspaces;
 
     // Add a row to the table for each workspace saved in the database
     for (var i = 0, ii = workspaces.length; i < ii; i++) {
         var workspace = workspaces[i];
-        var tableRow = $('<tr>');
-        tableRow.attr('value', workspace.id);
-        var workspaceEntry = $('<td>');
-        workspaceEntry.text(workspace.name);
-        tableRow.append(workspaceEntry);
-        table.append(tableRow);
+	var languages = [];
+	if (!workspace.blockly_enabled && !workspace.python_enabled || workspace.blockly_enabled && BLOCKLY_ENABLED || workspace.python_enabled && PYTHON_ENABLED) {
+		table.append("<tr value=\""+workspace.id +"\"> <td>" + workspace.name+  "</td></tr>");
+		}
+	// Add a function to make it work for old levels with defaults to false. 
     }
 };
 

--- a/game/static/game/js/level_editor.js
+++ b/game/static/game/js/level_editor.js
@@ -937,23 +937,7 @@ ocargo.LevelEditor = function() {
                         status = 'unshared';
                         allShared = false;
                     }
-
-                    var tableRow = $('<tr>');
-                    tableRow.attr( {
-                        'value': recipient.id,
-                        'status': status,
-                    });
-                    var rowName = $('<td>').text(recipient.name);
-
-                    var rowStatus = $('<td>');
-                    rowStatus.attr( {
-                        'class': 'share_cell'
-                    });
-                    rowStatus.text(text[status]);
-                    tableRow.append(rowName);
-                    tableRow.append(rowStatus);
-
-                    table.append(tableRow);
+                    table.append("<tr value=\""+recipient.id+"\" status=\""+status+"\"><td>"+ recipient.name +"</td><td class=\"share_cell\">"+ text[status] + "</td></tr>");
                 }
 
                 // Update the shareWithAll button
@@ -1033,22 +1017,11 @@ ocargo.LevelEditor = function() {
                 return 0;
             });
 
-            // Add a row to the table for each workspace saved in the database
+            // Add a row to the table for each level saved in the database
             for (var i = 0, ii = levels.length; i < ii; i++) {
                 var level = levels[i];
-                var tableRow = $('<tr>');
-                tableRow.attr({
-                    'value': level.id
-                });
-                var rowName = $('<td>');
-                rowName.text(level.name);
-                var rowOwner = $('<td>');
-                rowOwner.text(level.owner);
-                tableRow.append(rowName);
-                tableRow.append(rowOwner);
-                table.append(tableRow);
+                table.append("<tr value=\""+level.id+"\"><td>"+ level.name +"</td><td>"+ level.owner + "</td></tr>");
             }
-
             for (var i = 0; i < 2; i++) {
                 var td = $('#' + tableName + ' td:eq(' + i + ')');
                 var td2 = $('#' + tableName + 'Header th:eq(' + i + ')');


### PR DESCRIPTION
A "python" workspace can't be loaded in a "blockly level" anymore. Also, you cannot overwrite an incompatible workspace.
This will only work for "new style" workspaces (I changed the model). Old workspaces will still show.
To Do: make it work for old workspaces, and improve the ux: add indication about: which level it was saved in, the date of creation, ... ?