### PR TITLE
Use the console email backend. Fixes #744

### DIFF
--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -47,6 +47,8 @@ DATABASES = {
     }
 }
 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 USE_I18N = True
 USE_L10N = True
 


### PR DESCRIPTION
For local development use the console email backend instead of generating real emails.
This will avoid spamming others, and make registering local users easier.