### PR TITLE
Switch to trusty beta infrastructure. Fixes #754

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: python
 python:
   - 2.7


### PR DESCRIPTION
xgettext 0.18.1 doesn't deal with strings concatenated with +
Precise only has 0.18.1, so by switching to trusty we get
0.18.3, which supports our strings.