### PR TITLE
Fix for #802

### DIFF
--- a/game/static/game/js/sound.js
+++ b/game/static/game/js/sound.js
@@ -150,14 +150,14 @@ ocargo.sound.tension = function() {
 };
 
 ocargo.sound.mute = function() {
-    this.playAudioBackup = Blockly.SOUNDS_;
-    Blockly.SOUNDS_ = {};
+    this.playAudioBackup = Blockly.mainWorkspace.SOUNDS_;
+    Blockly.mainWorkspace.SOUNDS_ = {};
 
     Howler.mute();
 };
 
 ocargo.sound.unmute = function() {
-    Blockly.SOUNDS_ = this.playAudioBackup || Blockly.SOUNDS_;
+    Blockly.mainWorkspace.SOUNDS_ = this.playAudioBackup || Blockly.mainWorkspace.SOUNDS_;
 
     Howler.unmute();
 };


### PR DESCRIPTION
After fix I've tested "Mute" button in Firefox under Debian Linux on two levels and Blockly sounds are muted now.