### PR TITLE
Testing level failures

### DIFF
--- a/game/end_to_end_tests/base_game_test.py
+++ b/game/end_to_end_tests/base_game_test.py
@@ -165,6 +165,15 @@ class BaseGameTest(SeleniumTestCase):
             .load_solution(workspace_id) \
             .run_out_of_fuel_program()
 
+    def running_a_red_light_test(self, level, workspace_file):
+        user_profile = self.login_once()
+
+        workspace_id = self.use_workspace(workspace_file, user_profile)
+
+        return self.go_to_level(level) \
+            .load_solution(workspace_id) \
+            .run_a_red_light_program()
+
     def not_delivered_everywhere_test(self, level, workspace_file):
         user_profile = self.login_once()
 

--- a/game/end_to_end_tests/base_game_test.py
+++ b/game/end_to_end_tests/base_game_test.py
@@ -181,7 +181,7 @@ class BaseGameTest(SeleniumTestCase):
 
         return self.go_to_level(level) \
             .load_solution(workspace_id) \
-            .run_program_that_does_not_deliver_everywhere()
+            .run_not_delivered_everywhere_program()
 
     def undefined_procedure_test(self, level, workspace_file):
         user_profile = self.login_once()

--- a/game/end_to_end_tests/base_game_test.py
+++ b/game/end_to_end_tests/base_game_test.py
@@ -45,6 +45,7 @@ from django_selenium_clean import selenium, SeleniumTestCase
 from . import custom_handler
 from portal.models import UserProfile
 from game.models import Workspace
+from game.views.level import load_workspace_solution
 from .game_page import GamePage
 from portal.tests.pageObjects.portal.home_page import HomePage
 from portal.tests.utils.organisation import create_organisation_directly
@@ -153,7 +154,34 @@ class BaseGameTest(SeleniumTestCase):
 
         return self.go_to_level(level) \
             .load_solution(workspace_id) \
-            .run_program_that_runs_out_of_instructions()
+            .run_out_of_instructions_program()
+
+    def running_out_of_fuel_test(self, level, workspace_file):
+        user_profile = self.login_once()
+
+        workspace_id = self.use_workspace(workspace_file, user_profile)
+
+        return self.go_to_level(level) \
+            .load_solution(workspace_id) \
+            .run_out_of_fuel_program()
+
+    def not_delivered_everywhere_test(self, level, workspace_file):
+        user_profile = self.login_once()
+
+        workspace_id = self.use_workspace(workspace_file, user_profile)
+
+        return self.go_to_level(level) \
+            .load_solution(workspace_id) \
+            .run_program_that_does_not_deliver_everywhere()
+
+    def undefined_procedure_test(self, level, workspace_file):
+        user_profile = self.login_once()
+
+        workspace_id = self.use_workspace(workspace_file, user_profile)
+
+        return self.go_to_level(level) \
+            .load_solution(workspace_id) \
+            .run_undefined_procedure_program()
 
     def use_workspace(self, workspace_file, user_profile):
         solution = self.read_solution(workspace_file)

--- a/game/end_to_end_tests/base_game_test.py
+++ b/game/end_to_end_tests/base_game_test.py
@@ -84,7 +84,7 @@ class BaseGameTest(SeleniumTestCase):
     def go_to_level(self, level_name):
         path = reverse('play_default_level', kwargs={'levelName': str(level_name)})
         self._go_to_path(path)
-        selenium.execute_script('ocargo.animation.FAST_ANIMATION_DURATION = 100;')
+        selenium.execute_script('ocargo.animation.FAST_ANIMATION_DURATION = 1;')
 
         return GamePage(selenium)
 

--- a/game/end_to_end_tests/data/blockly_solutions/not_delivered_everywhere.xml
+++ b/game/end_to_end_tests/data/blockly_solutions/not_delivered_everywhere.xml
@@ -1,0 +1,64 @@
+<xml>
+    <block type="start" deletable="false" x="393" y="296">
+        <next>
+            <block type="turn_right">
+                <next>
+                    <block type="turn_left">
+                        <next>
+                            <block type="move_forwards">
+                                <next>
+                                    <block type="move_forwards">
+                                        <next>
+                                            <block type="move_forwards">
+                                                <next>
+                                                    <block type="turn_left">
+                                                        <next>
+                                                            <block type="move_forwards">
+                                                                <next>
+                                                                    <block type="move_forwards">
+                                                                        <next>
+                                                                            <block type="move_forwards">
+                                                                                <next>
+                                                                                    <block type="turn_right">
+                                                                                        <next>
+                                                                                            <block type="deliver">
+                                                                                                <next>
+                                                                                                    <block type="move_forwards">
+                                                                                                        <next>
+                                                                                                            <block type="turn_left">
+                                                                                                                <next>
+                                                                                                                    <block type="move_forwards">
+                                                                                                                        <next>
+                                                                                                                            <block type="deliver"></block>
+                                                                                                                        </next>
+                                                                                                                    </block>
+                                                                                                                </next>
+                                                                                                            </block>
+                                                                                                        </next>
+                                                                                                    </block>
+                                                                                                </next>
+                                                                                            </block>
+                                                                                        </next>
+                                                                                    </block>
+                                                                                </next>
+                                                                            </block>
+                                                                        </next>
+                                                                    </block>
+                                                                </next>
+                                                            </block>
+                                                        </next>
+                                                    </block>
+                                                </next>
+                                            </block>
+                                        </next>
+                                    </block>
+                                </next>
+                            </block>
+                        </next>
+                    </block>
+                </next>
+            </block>
+        </next>
+    </block>
+</xml>
+            

--- a/game/end_to_end_tests/data/blockly_solutions/running_a_red_light.xml
+++ b/game/end_to_end_tests/data/blockly_solutions/running_a_red_light.xml
@@ -1,0 +1,19 @@
+<xml>
+    <block type="start" deletable="false" x="230" y="130">
+        <next>
+            <block type="move_forwards">
+                <next>
+                    <block type="move_forwards">
+                        <next>
+                            <block type="move_forwards">
+                                <next>
+                                    <block type="move_forwards"></block>
+                                </next>
+                            </block>
+                        </next>
+                    </block>
+                </next>
+            </block>
+        </next>
+    </block>
+</xml>

--- a/game/end_to_end_tests/data/blockly_solutions/running_out_of_fuel.xml
+++ b/game/end_to_end_tests/data/blockly_solutions/running_out_of_fuel.xml
@@ -1,0 +1,24 @@
+<xml>
+    <block type="start" deletable="false" x="230" y="130">
+        <next>
+            <block type="move_forwards">
+                <next>
+                    <block type="controls_repeat_while">
+                        <value name="condition">
+                            <block type="road_exists">
+                                <field name="CHOICE">FORWARD</field>
+                            </block>
+                        </value>
+                        <statement name="body">
+                            <block type="turn_around">
+                                <next>
+                                    <block type="turn_around"></block>
+                                </next>
+                            </block>
+                        </statement>
+                    </block>
+                </next>
+            </block>
+        </next>
+    </block>
+</xml>

--- a/game/end_to_end_tests/data/blockly_solutions/running_out_of_instructions.xml
+++ b/game/end_to_end_tests/data/blockly_solutions/running_out_of_instructions.xml
@@ -1,0 +1,15 @@
+<xml>
+    <block type="start" deletable="false" x="230" y="130">
+        <next>
+            <block type="move_forwards">
+                <next>
+                    <block type="move_forwards">
+                        <next>
+                            <block type="turn_left"></block>
+                        </next>
+                    </block>
+                </next>
+            </block>
+        </next>
+    </block>
+</xml>

--- a/game/end_to_end_tests/data/blockly_solutions/undefined_procedure.xml
+++ b/game/end_to_end_tests/data/blockly_solutions/undefined_procedure.xml
@@ -1,0 +1,15 @@
+<xml>
+    <block type="start" deletable="false" x="230" y="130">
+        <next>
+            <block type="call_proc">
+                <field name="NAME">waggle</field>
+            </block>
+        </next>
+    </block>
+    <block type="declare_proc" x="380" y="630">
+        <field name="NAME">wiggle</field>
+        <statement name="DO">
+            <block type="move_forwards"></block>
+        </statement>
+    </block>
+</xml>

--- a/game/end_to_end_tests/game_page.py
+++ b/game/end_to_end_tests/game_page.py
@@ -157,6 +157,9 @@ class GamePage(BasePage):
     def run_out_of_fuel_program(self):
         return self._run_failing_program("You ran out of fuel!")
 
+    def run_a_red_light_program(self):
+        return self._run_failing_program("Uh oh, you just sent the van through a red light!")
+
     def run_program_that_does_not_deliver_everywhere(self):
         return self._run_failing_program("There are destinations that have not been delivered to.")
 

--- a/game/end_to_end_tests/game_page.py
+++ b/game/end_to_end_tests/game_page.py
@@ -160,7 +160,7 @@ class GamePage(BasePage):
     def run_a_red_light_program(self):
         return self._run_failing_program("Uh oh, you just sent the van through a red light!")
 
-    def run_program_that_does_not_deliver_everywhere(self):
+    def run_not_delivered_everywhere_program(self):
         return self._run_failing_program("There are destinations that have not been delivered to.")
 
     def run_undefined_procedure_program(self):

--- a/game/end_to_end_tests/game_page.py
+++ b/game/end_to_end_tests/game_page.py
@@ -151,8 +151,17 @@ class GamePage(BasePage):
     def run_cow_crashing_program(self):
         return self._run_failing_program("You ran into a cow!")
 
-    def run_program_that_runs_out_of_instructions(self):
+    def run_out_of_instructions_program(self):
         return self._run_failing_program("The van ran out of instructions before it reached a destination.")
+
+    def run_out_of_fuel_program(self):
+        return self._run_failing_program("You ran out of fuel!")
+
+    def run_program_that_does_not_deliver_everywhere(self):
+        return self._run_failing_program("There are destinations that have not been delivered to.")
+
+    def run_undefined_procedure_program(self):
+        return self._run_procedure_error_program("Your program doesn't look quite right...")
 
     def run_parse_error_program(self):
         return self._run_python_failing_program("v.", "ParseError: bad input on line")
@@ -212,6 +221,11 @@ class GamePage(BasePage):
     def _write_code(self, code):
         self.browser.execute_script("ocargo.pythonControl.appendCode(arguments[0])", code)
         return self
+
+    def _run_procedure_error_program(self, text):
+        self.run_program('close_button')
+        error_message = self.browser.find_element_by_id('myModal-mainText').text
+        assert_that(error_message, contains_string(text))
 
     def _assert_score(self, element_id, score):
         score_text = self.browser.find_element_by_id(element_id).text

--- a/game/end_to_end_tests/test_level_failures.py
+++ b/game/end_to_end_tests/test_level_failures.py
@@ -85,7 +85,3 @@ class TestCrashes(BaseGameTest):
             .clear()
 
         complete_and_check_level(6, page)
-
-
-
-

--- a/game/end_to_end_tests/test_level_failures.py
+++ b/game/end_to_end_tests/test_level_failures.py
@@ -72,7 +72,7 @@ class TestCrashes(BaseGameTest):
     def test_running_out_of_fuel(self):
         self.running_out_of_fuel_test(level=68, workspace_file='running_out_of_fuel')
 
-    def test_not_delivered_everywhere_test(self):
+    def test_not_delivered_everywhere(self):
         self.not_delivered_everywhere_test(level=16, workspace_file='not_delivered_everywhere')
 
     def test_procedure_undefined(self):

--- a/game/end_to_end_tests/test_level_failures.py
+++ b/game/end_to_end_tests/test_level_failures.py
@@ -72,6 +72,9 @@ class TestCrashes(BaseGameTest):
     def test_running_out_of_fuel(self):
         self.running_out_of_fuel_test(level=68, workspace_file='running_out_of_fuel')
 
+    def test_running_a_red_light(self):
+        self.running_a_red_light_test(level=44, workspace_file='running_a_red_light')
+
     def test_not_delivered_everywhere(self):
         self.not_delivered_everywhere_test(level=16, workspace_file='not_delivered_everywhere')
 

--- a/game/end_to_end_tests/test_level_failures.py
+++ b/game/end_to_end_tests/test_level_failures.py
@@ -66,6 +66,18 @@ class TestCrashes(BaseGameTest):
     def test_crash_going_right_on_t_junction(self):
         self.run_crashing_test(level=40, workspace_file='crash_going_right_on_t_junction')
 
+    def test_running_out_of_instructions(self):
+        self.running_out_of_instructions_test(level=6, workspace_file='running_out_of_instructions')
+
+    def test_running_out_of_fuel(self):
+        self.running_out_of_fuel_test(level=68, workspace_file='running_out_of_fuel')
+
+    def test_not_delivered_everywhere_test(self):
+        self.not_delivered_everywhere_test(level=16, workspace_file='not_delivered_everywhere')
+
+    def test_procedure_undefined(self):
+        self.undefined_procedure_test(level=63, workspace_file='undefined_procedure')
+
     def test_crash_turning_left_clear_and_pass_level(self):
         page = self\
             .run_crashing_test(level=6, workspace_file='crash_turning_left_on_straight_road')\


### PR DESCRIPTION
Added tests which make sure blockly levels fail when:
- the van runs out of fuel
- the van runs out of instructions
- the van runs a red light
- the van doesn't deliver to every destination
- a procedure is undefined in blockly