### PR TITLE
No more solve button for custom levels.

### DIFF
--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -500,7 +500,7 @@ ocargo.Game.prototype._setupTabs = function () {
     this._setupQuitTab();
     this._setupNightModeTab();
 
-    if (USER_STATUS === 'TEACHER' && LEVEL_NAME <= 109){
+    if (USER_STATUS === 'TEACHER' && DEFAULT_LEVEL){
         this.tabs.solution = new ocargo.Tab($('#solution_radio'), $('#solution_radio + label'));
         this._setupSolutionTab();
         $('#solution_tab').show()

--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -500,7 +500,7 @@ ocargo.Game.prototype._setupTabs = function () {
     this._setupQuitTab();
     this._setupNightModeTab();
 
-    if (USER_STATUS === 'TEACHER'){
+    if (USER_STATUS === 'TEACHER' && LEVEL_NAME <= 109){
         this.tabs.solution = new ocargo.Tab($('#solution_radio'), $('#solution_radio + label'));
         this._setupSolutionTab();
         $('#solution_tab').show()


### PR DESCRIPTION
Instead of just checking if user is a teacher, also check if the level is one of the official RR levels. If not, the solve button isn't created.

Coverage increased by 0.7%.