### PR TITLE
Improved assert_score function.

### DIFF
--- a/game/end_to_end_tests/game_page.py
+++ b/game/end_to_end_tests/game_page.py
@@ -155,8 +155,9 @@ class GamePage(BasePage):
         return self
 
     def _assert_score(self, element_id, score):
-        route_score = self.browser.find_element_by_id(element_id).text
-        assert_that(route_score, starts_with(str(score)))
+        score_text = self.browser.find_element_by_id(element_id).text
+        score_number = score_text.split("/")[0]
+        assert_that(score_number, equal_to(str(score)))
         return self
 
     def assert_success(self):


### PR DESCRIPTION
To test if the score earned at the end of a level is equal to the score passed in as an argument:

- Before: the test checked if the score string (of format x/10) **started with** the argument score x. This was flawed as there could be cases where the test would succeed unexpectedly 
ie: score string = "10/10", argument score = 1.

- Now: the score string is split at character '/'. The substring before is compared to the argument score and if the two are **equal**, the test succeeds.

Coverage: decreased by 0.09% because of random_road.py which has not been edited in this pull request.