### PR TITLE
Fixes #820

### DIFF
--- a/game/static/game/js/blocklyCompiler.js
+++ b/game/static/game/js/blocklyCompiler.js
@@ -209,8 +209,7 @@ ocargo.BlocklyCompiler.prototype.getCondition = function(conditionBlock) {
     	return this.negateCondition(
             this.getCondition(conditionBlock.inputList[0].connection.targetBlock()));
     } else if (conditionBlock.type === 'traffic_light') {
-    	return this.trafficLightCondition(
-            conditionBlock, conditionBlock.inputList[0].fieldRow[1].value_);
+    	return this.trafficLightCondition(conditionBlock);
     } else if (conditionBlock.type === 'declare_event') {
         return this.cowCrossingCondition(conditionBlock);
     }
@@ -295,7 +294,8 @@ ocargo.BlocklyCompiler.prototype.simplifyBlock = function(block){
 
 /** Conditions **/
 
-ocargo.BlocklyCompiler.prototype.trafficLightCondition = function(block, lightColour) {
+ocargo.BlocklyCompiler.prototype.trafficLightCondition = function(block) {
+    var lightColour = block.getFieldValue('CHOICE');
     return function(model) {
         queueHighlight(model, block);
         if (lightColour === ocargo.TrafficLight.RED) {
@@ -535,8 +535,7 @@ ocargo.BlocklyCompiler.prototype.mobileGetCondition = function(conditionBlock) {
         return this.negateCondition(
             this.getCondition(conditionBlock.inputList[0].connection.targetBlock()));
     } else if (conditionBlock.type === 'traffic_light') {
-        return this.trafficLightCondition(
-            conditionBlock, conditionBlock.inputList[0].fieldRow[1].value_);
+        return this.trafficLightCondition(conditionBlock);
     } else{
         return null;
     }


### PR DESCRIPTION
The order of fields may be different depending on the translation. The reason:

"In Blockly for Web, if all of the human readable strings share the some prefix or suffix, those strings will extracted as a label before or after the drop down. This allows the prefix/suffix label place to adapt to language conventions. This feature will be ported to Android in the near future."

https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks#drop-down_field