### PR TITLE
Selenium tests timeout fix

### DIFF
--- a/game/end_to_end_tests/base_game_test.py
+++ b/game/end_to_end_tests/base_game_test.py
@@ -63,7 +63,7 @@ class BaseGameTest(SeleniumTestCase):
     user_profile = None
 
     def _go_to_path(self, path):
-        socket.setdefaulttimeout(5)
+        socket.setdefaulttimeout(20)
         attempts = 0
         while True:
             try:


### PR DESCRIPTION
Timeout value was too low, causing random tests to timeout before actually running.