### PR TITLE
Makes Levels accessible on admin page

### DIFF
--- a/game/admin.py
+++ b/game/admin.py
@@ -36,8 +36,13 @@
 # identified as the original program.
 from django.contrib import admin
 from game.models import Level, Block, Episode, Workspace
+
+
+class LevelAdmin(admin.ModelAdmin):
+    readonly_fields = ['owner']
+
   
-admin.site.register(Level)
+admin.site.register(Level, LevelAdmin)
 admin.site.register(Workspace)
 admin.site.register(Episode)
 admin.site.register(Block)


### PR DESCRIPTION
The Level model's owner foreign key caused the page loading to time out by trying to load all values in a select dropdown. This field is now readonly.