### PR TITLE
Specifies file extension for correct Sass import

### DIFF
--- a/game/static/game/sass/game.scss
+++ b/game/static/game/sass/game.scss
@@ -38,7 +38,7 @@ identified as the original program.
 @import '../../scss/foundation';
 @import 'variables';
 @import '../../bourbon/bourbon';
-@import '../../foundation-icons';
+@import '../../foundation-icons.scss';
 
 .size-12 { font-size: 12px; }
 


### PR DESCRIPTION
View #988 for details on previous fix. The file extension needs to be specified here because of the way the foundation-icons package is structured. It contains both .css and .scss files, which very recently became an issue as game.scss doesn't know which of these two files to import if the extension isn't specified. Re-applying this fix here to be able to successfully deploy to staging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1000)
<!-- Reviewable:end -->
