### PR TITLE
Removes user levels from episodes

### DIFF
--- a/game/migrations/0069_remove_user_levels_from_episodes.py
+++ b/game/migrations/0069_remove_user_levels_from_episodes.py
@@ -35,33 +35,17 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 from django.db import migrations
-from django.db.utils import OperationalError
 
 
 def update_episodes_level_order(apps, schema_editor):
     Episode = apps.get_model('game', 'Episode')
+    Level = apps.get_model('game', 'Level')
+
     episode7 = Episode.objects.get(id=7)
     episode8 = Episode.objects.get(id=8)
 
-    episode7_levels = episode7.level_set.all()
-    episode8_levels = episode8.level_set.all()
-
-    episode7_new_levels = []
-    episode8_new_levels = []
-
-    for episode7_level in episode7_levels:
-        try:
-            if not episode7_level.owner:
-                episode7_new_levels.append(episode7_level)
-        except OperationalError:
-            pass
-
-    for episode8_level in episode8_levels:
-        try:
-            if not episode8_level.owner:
-                episode8_new_levels.append(episode8_level)
-        except OperationalError:
-            pass
+    episode7_new_levels = Level.objects.filter(episode=episode7, owner=None)
+    episode8_new_levels = Level.objects.filter(episode=episode8, owner=None)
 
     episode7.level_set = episode7_new_levels
     episode8.level_set = episode8_new_levels

--- a/game/migrations/0069_remove_user_levels_from_episodes.py
+++ b/game/migrations/0069_remove_user_levels_from_episodes.py
@@ -35,25 +35,36 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 from django.db import migrations
+from django.db.utils import OperationalError
 
 
 def update_episodes_level_order(apps, schema_editor):
-    Level = apps.get_model('game', 'Level')
-    episode7_levels = []
-    episode8_levels = []
-
-    for episode7_level_name in range(51, 61):
-        episode7_levels.append(Level.objects.get(name=episode7_level_name))
-
-    for episode8_level_name in range(61, 68):
-        episode8_levels.append(Level.objects.get(name=episode8_level_name))
-
     Episode = apps.get_model('game', 'Episode')
     episode7 = Episode.objects.get(id=7)
     episode8 = Episode.objects.get(id=8)
 
-    episode7.level_set = episode7_levels
-    episode8.level_set = episode8_levels
+    episode7_levels = episode7.level_set.all()
+    episode8_levels = episode8.level_set.all()
+
+    episode7_new_levels = []
+    episode8_new_levels = []
+
+    for episode7_level in episode7_levels:
+        try:
+            if not episode7_level.owner:
+                episode7_new_levels.append(episode7_level)
+        except OperationalError:
+            pass
+
+    for episode8_level in episode8_levels:
+        try:
+            if not episode8_level.owner:
+                episode8_new_levels.append(episode8_level)
+        except OperationalError:
+            pass
+
+    episode7.level_set = episode7_new_levels
+    episode8.level_set = episode8_new_levels
 
     episode7.save()
     episode8.save()

--- a/game/tests/migrations/test_migration_fix_episodes_order.py
+++ b/game/tests/migrations/test_migration_fix_episodes_order.py
@@ -40,7 +40,7 @@ from base_test_migration import MigrationTestCase
 class TestMigrationReorderEpisodes(MigrationTestCase):
 
     start_migration = '0067_level_score_27'
-    dest_migration = '0069_fix_episodes_order_part_2'
+    dest_migration = '0069_remove_user_levels_from_episodes'
 
     def test_episodes_renamed_properly(self):
         Episode = self.django_application.get_model('game', 'Episode')


### PR DESCRIPTION
Edited migration 69 to go through episodes 7 and 8's levels, pick the ones that have the right name *as well as* no associated owner (this means it was created by us) and add it to a new list. The new list of original levels only replaces the current content of the episodes to fix the current issue.

Since this migration wasn't applied to production in the latest deployment, simply editing it is enough instead of having to create a new one - I have tested this locally to make sure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1006)
<!-- Reviewable:end -->
