### PR TITLE
Makes scoreboard visible when data is selected

### DIFF
--- a/game/static/game/css/scoreboard.css
+++ b/game/static/game/css/scoreboard.css
@@ -88,10 +88,6 @@ table tbody td {
 	background: #C24563;
 }
 
-.tableWrapper {
-	visibility: hidden;
-}
-
 #scoreboardTable tr td.untouched {
 	background: #d9d9d9;
 }

--- a/game/templates/game/scoreboard.html
+++ b/game/templates/game/scoreboard.html
@@ -62,7 +62,6 @@
             new $.fn.dataTable.FixedColumns(table, {
                 leftColumns: 2
             });
-            $(".tableWrapper").css('visibility', 'visible');
             document.getElementById("tableWrapper").scrollIntoView();
         }
     });


### PR DESCRIPTION
- Removed the default 'invisible' setting of the tableWrapper class in CSS.
- Removed the JS line which makes it visible upon document load - which was probably not working well enough on production.
- Now, the scoreboard works normally since, when no data is selected, the scoreboard doesn't have anything to show, and when data is selected, it is by default visible and shows the appropriate data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1010)
<!-- Reviewable:end -->
