### PR TITLE
fix(.travis.yml): reinstate Semaphore curl request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,5 @@ jobs:
         - git config --global user.email "semantic-release@travis"
         - pip install python-semantic-release==3.11.2
         - semantic-release publish
+      after_success:
+        - "curl -d POST -v https://semaphoreci.com/api/v1/projects/${SEMAPHORE_PROJECT_ID}/master/build?auth_token=${SEMAPHORE_API_AUTH}"


### PR DESCRIPTION
## Description
The config line to deploy to Semaphore had been removed by mistake, so this PR is adding it back in. It has been put after the success of the deploy stage.

## How Has This Been Tested?
The success of this can only be checked once this PR has been merged.

## Checklist:
- [ ] The Travis build launches a Semaphore build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1021)
<!-- Reviewable:end -->
