### PR TITLE
refactor: Make URLs consistent with deployed project

### DIFF
--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Code for Life
 #
-# Copyright (C) 2016, Ocado Innovation Limited
+# Copyright (C) 2019, Ocado Innovation Limited
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -34,7 +34,7 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-'''Django settings for example_project project.'''
+"""Django settings for example_project project."""
 import os
 
 DEBUG = True
@@ -50,8 +50,8 @@ TEMPLATES = [
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': os.path.join(os.path.abspath(os.path.dirname(__file__)),'db.sqlite3'),# Or path to database file if using sqlite3.
+        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': os.path.join(os.path.abspath(os.path.dirname(__file__)),'db.sqlite3'),  # Or path to database file if using sqlite3.
     }
 }
 
@@ -67,7 +67,7 @@ STATIC_ROOT = os.path.join(os.path.dirname(__file__), 'static')
 STATIC_URL = '/static/'
 SECRET_KEY = 'not-a-secret'
 
-ROOT_URLCONF = 'django_autoconfig.autourlconf'
+ROOT_URLCONF = 'example_project.urls'
 
 WSGI_APPLICATION = 'example_project.wsgi.application'
 
@@ -78,7 +78,7 @@ INSTALLED_APPS = (
 PIPELINE_ENABLED = False
 
 try:
-    from example_project.local_settings import * # pylint: disable=E0611
+    from example_project.local_settings import *  # pylint: disable=E0611
 except ImportError:
     pass
 

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -1,0 +1,12 @@
+from django.conf.urls import include, patterns, url
+from django.contrib import admin
+
+admin.autodiscover()
+
+urlpatterns = patterns(
+    '',
+    url(r'^', include('portal.urls')),
+    url(r'^administration/', include(admin.site.urls)),
+    url(r'^rapidrouter/', include('game.urls')),
+    url(r'^aimmo/', include('aimmo.urls')),
+)

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,4 +1,3 @@
-import os
 from selenium import webdriver
 
 SELENIUM_WEBDRIVERS = {
@@ -19,11 +18,12 @@ DATABASES = {
         'ENGINE': 'django.db.backends.sqlite3',
     },
 }
+
 INSTALLED_APPS = ['game']
 PIPELINE_ENABLED = False
-ROOT_URLCONF = 'django_autoconfig.autourlconf'
-SECRET_KEY = 'test'
+ROOT_URLCONF = 'example_project.example_project.urls'
 STATIC_ROOT = 'example_project/example_project/static/'
+SECRET_KEY = 'test'
 
 from django_autoconfig.autoconfig import configure_settings
 configure_settings(globals())


### PR DESCRIPTION
## Description
We're adding URLs to the example project to make the URLs consistent throughout the projects.

## How Has This Been Tested?
This has been tested by running the tests locally and successfully checking that the URLs were the correct ones.

## Checklist:
- [x] Portal URLs don't end with `/portal`.
- [x] All tests pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1023)
<!-- Reviewable:end -->
