### PR TITLE
build: Upgrade django rest framework to 3.6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "django-pipeline==1.5.4",
         "django-appconf==1.0.1",
         "django-casper==0.0.3",
-        "djangorestframework>=3.1.3, <=3.2.3",
+        "djangorestframework>=3.6, <=3.7",
         "six==1.11.0",
         "docutils==0.12",
         "pyhamcrest==1.8.3",


### PR DESCRIPTION
BREAKING CHANGE: this will temporarily break codeforlife-portal and deployment as it will be expecting an older version of the django rest framework

## Description
Upgrade django rest framework to the latest version we can have with our current Django version

## How Has This Been Tested?
By existing tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1029)
<!-- Reviewable:end -->
