### PR TITLE
build: Disable test stage on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   fast_finish: true
 stages:
   - name: test
-    if: tag IS blank
+    if: tag IS blank AND (NOT branch = master)
   - name: deploy
     if: branch = master AND (NOT type IN (pull_request))
 jobs:


### PR DESCRIPTION
## Description
Every time a PR is merged, it re-runs the tests on master. Since the tests have already passed at that point, disabling the test stage will save us time.