### PR TITLE
fix: Make travis point to codeforlife-portal’s default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
       install:
         - pip install -U setuptools
         - pip install -e .
-        - pip install -e git+https://github.com/ocadotechnology/codeforlife-portal.git@upgrade-django-19-110#egg=codeforlife-portal #TODO: Remove as part of #688
+        - pip install -e git+https://github.com/ocadotechnology/codeforlife-portal.git#egg=codeforlife-portal #TODO: Remove as part of #688
         - pip install coveralls
         - pip install crowdin-cli-py
       before_script:
@@ -46,7 +46,7 @@ jobs:
       install:
         - pip install -U setuptools
         - pip install -e .
-        - pip install -e git+https://github.com/ocadotechnology/codeforlife-portal.git@upgrade-django-19-110#egg=codeforlife-portal #TODO: Remove as part of #688
+        - pip install -e git+https://github.com/ocadotechnology/codeforlife-portal.git#egg=codeforlife-portal #TODO: Remove as part of #688
         - python setup.py install
         - pip install crowdin-cli-py
       script:


### PR DESCRIPTION
## Description
Now that portal is on Django 1.10, we can use the default branch (master) of portal to run our tests against

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1033)
<!-- Reviewable:end -->
