### PR TITLE
fix: Uses serializer to load level in editor

### DIFF
--- a/game/tests/test_level_editor.py
+++ b/game/tests/test_level_editor.py
@@ -200,3 +200,13 @@ class LevelEditorTestCase(TestCase):
 
         sharing_info1 = json.loads(self.get_sharing_information(level_id).getvalue())
         assert_that(len(sharing_info1["teachers"]), equal_to(0))
+
+    def test_level_loading(self):
+        teacher1, email1, password1 = signup_teacher_directly()
+
+        self.login(email1, password1)
+        level_id = create_save_level(teacher1)
+        url = reverse("load_level_for_editor", kwargs={"levelID": level_id})
+        response = self.client.get(url)
+
+        assert_that(response.status_code, equal_to(200))

--- a/game/views/level.py
+++ b/game/views/level.py
@@ -43,6 +43,7 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404
 from django.utils import timezone
 from django.utils.safestring import mark_safe
+from rest_framework import serializers
 
 import game.level_management as level_management
 import game.messages as messages
@@ -420,3 +421,9 @@ def delete_workspace(request, workspaceID):
         workspace.delete()
 
     return load_list_of_workspaces(request)
+
+
+class LevelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Level
+        fields = "__all__"

--- a/game/views/level_editor.py
+++ b/game/views/level_editor.py
@@ -42,7 +42,6 @@ import re
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import transaction
-from django.forms.models import model_to_dict
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render, redirect
 from django.utils.safestring import mark_safe
@@ -59,6 +58,7 @@ from game.character import get_all_character
 from game.decor import get_all_decor, get_decor_element
 from game.models import Level, Block
 from game.theme import get_all_themes
+from game.views.level import LevelSerializer
 
 
 def level_editor(request):
@@ -68,7 +68,8 @@ def level_editor(request):
 
     ``RequestContext``
     ``blocks``
-        Blocks that can be chosen to be played with later on. List of :model:`game.Block`.
+        Blocks that can be chosen to be played with later on.
+        List of :model:`game.Block`.
 
     **Template:**
 
@@ -221,7 +222,7 @@ def load_level_for_editor(request, levelID):
     if not permissions.can_load_level(request.user, level):
         return HttpResponseUnauthorized()
 
-    level_dict = model_to_dict(level)
+    level_dict = LevelSerializer(level).data
     level_dict["theme"] = level.theme.id
     level_dict["decor"] = cached_level_decor(level)
     level_dict["blocks"] = cached_level_blocks(level)
@@ -247,7 +248,8 @@ def save_level_for_editor(request, levelId=None):
     pattern = re.compile("^(\w?[ ]?)*$")
     if pattern.match(data["name"]):
         level_management.save_level(level, data)
-        # Add the teacher automatically if it is a new level and the student is not independent
+        # Add the teacher automatically if it is a new level and the student is not
+        # independent
         if (
             (levelId is None)
             and hasattr(level.owner, "student")
@@ -285,7 +287,9 @@ def delete_level_for_editor(request, levelId):
 
 
 def generate_random_map_for_editor(request):
-    """Generates a new random path suitable for a random level with the parameters provided"""
+    """
+    Generates a new random path suitable for a random level with the parameters provided
+    """
     data = dict(request.POST)
 
     size = int(data["numberOfTiles"][0])


### PR DESCRIPTION
## Description
Using Django's `model_to_dict` function stopped working after the Django 1.10 upgrade, as such we've replaced it with Django Rest Framework's serializer.

## How Has This Been Tested?
A Unit test has been added to test when a user loads a level in the game editor. It's been checked to pass after the changes, and fail before the changes.

## Checklist:
- [x] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1036)
<!-- Reviewable:end -->
