### PR TITLE
fix: add Blockly event to run program on Start Block click

### DIFF
--- a/game/static/game/js/blocklyControl.js
+++ b/game/static/game/js/blocklyControl.js
@@ -96,7 +96,6 @@ ocargo.BlocklyControl.prototype.reset = function() {
 
     var startBlock = this.createBlock('start');
     startBlock.moveBy(30+(i%2)*200,30+Math.floor(i/2)*100);
-    this.blocklyCustomisations.addClickListenerToStartBlock(startBlock);
 
     this.clearIncorrectBlock();
 };
@@ -136,7 +135,7 @@ ocargo.BlocklyControl.prototype.deserialize = function(text) {
             Blockly.mainWorkspace.clear();
             Blockly.Xml.domToWorkspace(oldXml, Blockly.mainWorkspace);
         }
-        this.blocklyCustomisations.addClickListenerToStartBlock(this.startBlock());
+        this.blocklyCustomisations.addClickListenerToStartBlock();
     } catch (e) {
         console.log(e);
         this.reset();

--- a/game/static/game/js/blocklyControl.js
+++ b/game/static/game/js/blocklyControl.js
@@ -57,6 +57,7 @@ ocargo.BlocklyControl = function () {
     Blockly.Flyout.autoClose = false;
 
     this.blocklyCustomisations.addLimitedBlockListeners(Blockly.mainWorkspace);
+    this.blocklyCustomisations.addClickListenerToStartBlock();
 };
 
 ocargo.BlocklyControl.BLOCK_HEIGHT = 20;
@@ -135,7 +136,6 @@ ocargo.BlocklyControl.prototype.deserialize = function(text) {
             Blockly.mainWorkspace.clear();
             Blockly.Xml.domToWorkspace(oldXml, Blockly.mainWorkspace);
         }
-        this.blocklyCustomisations.addClickListenerToStartBlock();
     } catch (e) {
         console.log(e);
         this.reset();

--- a/game/static/game/js/blocklyCustomisations.js
+++ b/game/static/game/js/blocklyCustomisations.js
@@ -281,16 +281,14 @@ ocargo.BlocklyCustomisations = function () {
         };
     };
 
-    this.addClickListenerToStartBlock = function(){
+    this.addClickListenerToStartBlock = function() {
         const play_button = $('#play_radio');
-        Blockly.mainWorkspace.addChangeListener(onStartBlockClick);
+        Blockly.mainWorkspace.addChangeListener(function(event) {
+            const startBlockID = Blockly.mainWorkspace.getBlocksByType('start')[0]['id'];
 
-        function onStartBlockClick(event) {
-            const startBlockID = Blockly.mainWorkspace.getBlocksByType("start")[0]["id"];
-
-            if (event.type == Blockly.Events.UI && event.element == "click" && event.blockId == startBlockID) {
+            if (event.type == Blockly.Events.UI && event.element == 'click' && event.blockId == startBlockID) {
                 play_button.trigger('click');
             }
-        }
+        });
     };
 };

--- a/game/static/game/js/blocklyCustomisations.js
+++ b/game/static/game/js/blocklyCustomisations.js
@@ -281,12 +281,16 @@ ocargo.BlocklyCustomisations = function () {
         };
     };
 
-    this.addClickListenerToStartBlock = function(startBlock){
-        if(startBlock){
-            var svgRoot = Blockly.mainWorkspace.getBlocksByType("start")[0].getSvgRoot().children[1];
-            svgRoot.addEventListener('click', function () {
-                $('#play_radio').trigger('click');
-            });
+    this.addClickListenerToStartBlock = function(){
+        const play_button = $('#play_radio');
+        Blockly.mainWorkspace.addChangeListener(onStartBlockClick);
+
+        function onStartBlockClick(event) {
+            const startBlockID = Blockly.mainWorkspace.getBlocksByType("start")[0]["id"];
+
+            if (event.type == Blockly.Events.UI && event.element == "click" && event.blockId == startBlockID) {
+                play_button.trigger('click');
+            }
         }
     };
 };


### PR DESCRIPTION
## Description
This PR adds a Blockly Event so that the workspace code runs when the user clicks the Start block.
This was necessary as the Blockly library was updated in #1042. 

The event listener listens for a event of type click, and it checks that the block that is clicked is the Start block. If it is, the listener triggers a click on the Play button, which runs the program.

NB: The line which adds the event listener to the Start block inside the `reset` method was removed as it was redundant.

## Checklist
- [x] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1046)
<!-- Reviewable:end -->
