### PR TITLE
fix: remove secondary buttons block to extend directly from portal

### DIFF
--- a/game/templates/game/base.html
+++ b/game/templates/game/base.html
@@ -10,13 +10,6 @@
   <link rel="manifest" href="{% static "manifest.json" %}">
 {% endblock head %}
 
-{% block secondaryButtons %}
-    {% block dashboard %}<a href="{% url 'dashboard' %}" class="button--menu button--menu--secondary button--menu--enabled">School / Club</a>{% endblock dashboard %}
-    {% block rapidrouter %}<a href="{% url 'levels' %}" class="button--menu button--menu--secondary button--menu--enabled button--menu--teacher--active">Rapid Router</a>{% endblock rapidrouter %}
-    {% block aimmo %}<a href="{% url 'play_aimmo' %}" class="button--menu button--menu--secondary button--menu--enabled">AI:MMO</a>{% endblock aimmo %}
-    {% block materials %}<a id="resources_button" href="{% url 'teaching_resources' %}" class="button--menu button--menu--secondary button--menu--enabled">Teaching Resources</a>{% endblock materials %}
-{% endblock secondaryButtons %}
-
 {% block subNav %}
 {{ block.super }}
 <div class="banner banner--teacher row">

--- a/game/templates/game/basenonav.html
+++ b/game/templates/game/basenonav.html
@@ -4,9 +4,6 @@
 
 {% block head %}
 <link rel="manifest" href="{% static "manifest.json" %}">
-<!-- <meta name="apple-mobile-web-app-capable" content="yes" />
-<meta name="apple-touch-fullscreen" content="yes" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" /> -->
   {% include 'game/crowdin.html' %}
 {% endblock head %}
 
@@ -18,13 +15,6 @@
 
 {% block topBar %}
 {% endblock topBar %}
-
-{% block secondaryButtons %}
-    {% block dashboard %}<a href="{% url 'dashboard' %}" class="button--menu button--menu--secondary button--menu--enabled">School / Club</a>{% endblock dashboard %}
-    {% block rapidrouter %}<a href="{% url 'levels' %}" class="button--menu button--menu--secondary button--menu--enabled button--menu--teacher--active">Rapid Router</a>{% endblock rapidrouter %}
-    {% block aimmo %}<a href="{% url 'play_aimmo' %}" class="button--menu button--menu--secondary button--menu--enabled">AI:MMO</a>{% endblock aimmo %}
-    {% block materials %}<a id="resources_button" href="{% url 'teaching_resources' %}" class="button--menu button--menu--secondary button--menu--enabled">Teaching Resources</a>{% endblock materials %}
-{% endblock secondaryButtons %}
 
 {% block subNav %}
 {% endblock subNav %}
@@ -61,24 +51,11 @@
     </section>
 {% endblock contentWrapper %}
 
-
-
 {% block footer %}
 {% endblock footer %}
 
 {% block scripts %}
     <script type='text/javascript' src="{% static 'game/js/svginnerhtml.js' %}"></script>
-
-    <!--<script>
-    // Disable rubber banding on ios tablets
-    $(function() {
-        document.body.addEventListener('touchmove', function(ev) {
-            ev.preventDefault();
-        }, false);
-
-        $(document.body).width(window.innerWidth).height(window.innerHeight);
-    });
-    </script>-->
 
     <script>
       $(function() {


### PR DESCRIPTION
## Description
This PR fixes the incorrect link to the AI:MMO home page from the RR project for preview access users.

The fix was to entirely remove the `secondaryButtons` section as it did not need to be here. This makes the RR `base` inherit the `secondaryButtons` section from the portal base directly without unnecessarily overriding it.

## Checklist:
- [x] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1049)
<!-- Reviewable:end -->
