### PR TITLE
fix: add django-compressor to compress js and css files to load pages faster

### DIFF
--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -65,6 +65,9 @@ LANGUAGE_CODE = 'en-gb'
 LANGUAGES = (('en-gb', 'English'),)
 STATIC_ROOT = os.path.join(os.path.dirname(__file__), 'static')
 STATIC_URL = '/static/'
+STATICFILES_FINDERS = (
+    'compressor.finders.CompressorFinder',
+)
 SECRET_KEY = 'not-a-secret'
 
 ROOT_URLCONF = 'example_project.urls'
@@ -73,9 +76,12 @@ WSGI_APPLICATION = 'example_project.wsgi.application'
 
 INSTALLED_APPS = (
     'game',
+    'compressor',
 )
 
 PIPELINE_ENABLED = False
+
+COMPRESS_ENABLED = True
 
 try:
     from example_project.local_settings import *  # pylint: disable=E0611

--- a/game/templates/game/base.html
+++ b/game/templates/game/base.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load i18n %}
 {% load app_tags %}
+{% load compress %}
 
 {% block title %}Code for Life - Rapid Router{% endblock %}
 
@@ -54,8 +55,10 @@
 
 {% block scripts %}
   {{block.super}}
-  <script type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
-  <script type='text/javascript' src='{% url 'js-reverse' %}'></script>
-  <script type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
-  <script type='text/javascript' src='{% static 'game/js/jquery.touchy.min.js' %}'></script>
+{% compress js %}
+  <script defer type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
+  <script defer type='text/javascript' src='{% static 'game/js/jquery.touchy.min.js' %}'></script>
+{% endcompress %}
+  <script defer type='text/javascript' src='{% url 'js-reverse' %}'></script>
+  <script defer type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
 {% endblock %}

--- a/game/templates/game/base.html
+++ b/game/templates/game/base.html
@@ -2,7 +2,6 @@
 {% load static %}
 {% load i18n %}
 {% load app_tags %}
-{% load compress %}
 
 {% block title %}Code for Life - Rapid Router{% endblock %}
 
@@ -55,10 +54,8 @@
 
 {% block scripts %}
   {{block.super}}
-{% compress js %}
   <script defer type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
-  <script defer type='text/javascript' src='{% static 'game/js/jquery.touchy.min.js' %}'></script>
-{% endcompress %}
   <script defer type='text/javascript' src='{% url 'js-reverse' %}'></script>
   <script defer type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
+  <script defer type='text/javascript' src='{% static 'game/js/jquery.touchy.min.js' %}'></script>
 {% endblock %}

--- a/game/templates/game/base.html
+++ b/game/templates/game/base.html
@@ -54,8 +54,8 @@
 
 {% block scripts %}
   {{block.super}}
-  <script defer type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
-  <script defer type='text/javascript' src='{% url 'js-reverse' %}'></script>
-  <script defer type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
-  <script defer type='text/javascript' src='{% static 'game/js/jquery.touchy.min.js' %}'></script>
+  <script type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
+  <script type='text/javascript' src='{% url 'js-reverse' %}'></script>
+  <script type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
+  <script type='text/javascript' src='{% static 'game/js/jquery.touchy.min.js' %}'></script>
 {% endblock %}

--- a/game/templates/game/basenonav.html
+++ b/game/templates/game/basenonav.html
@@ -1,6 +1,7 @@
 {% extends 'portal/base_old.html' %}
 {% load staticfiles %}
 {% load pipeline %}
+{% load compress %}
 
 {% block head %}
 <link rel="manifest" href="{% static "manifest.json" %}">
@@ -55,17 +56,19 @@
 {% endblock footer %}
 
 {% block scripts %}
-    <script type='text/javascript' src="{% static 'game/js/svginnerhtml.js' %}"></script>
-    <script>
+{% compress js %}
+    <script defer type='text/javascript' src="{% static 'game/js/svginnerhtml.js' %}"></script>
+    <script defer>
       $(function() {
         $(document).foundation();
       });
     </script>
-    <script type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
-    <script type='text/javascript' src='{% static 'game/js/foundation/foundation.min.js' %}'></script>
-    <script type='text/javascript' src='{% static 'game/js/handlebars.runtime-v3.0.3.js' %}'></script>
-    <script type='text/javascript' src='{% static 'game/js/templates.js' %}'></script>
-    <script type='text/javascript' src='{% static 'game/js/button.js' %}'></script>
-    <script type='text/javascript' src='{% url 'js-reverse' %}'></script>
-    <script type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
+    <script defer type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
+    <script defer type='text/javascript' src='{% static 'game/js/foundation/foundation.min.js' %}'></script>
+    <script defer type='text/javascript' src='{% static 'game/js/handlebars.runtime-v3.0.3.js' %}'></script>
+    <script defer type='text/javascript' src='{% static 'game/js/templates.js' %}'></script>
+    <script defer type='text/javascript' src='{% static 'game/js/button.js' %}'></script>
+{% endcompress %}
+    <script defer type='text/javascript' src='{% url 'js-reverse' %}'></script>
+    <script defer type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
 {% endblock %}

--- a/game/templates/game/basenonav.html
+++ b/game/templates/game/basenonav.html
@@ -57,18 +57,18 @@
 
 {% block scripts %}
 {% compress js %}
-    <script defer type='text/javascript' src="{% static 'game/js/svginnerhtml.js' %}"></script>
-    <script defer>
+    <script type='text/javascript' src="{% static 'game/js/svginnerhtml.js' %}"></script>
+    <script>
       $(function() {
         $(document).foundation();
       });
     </script>
-    <script defer type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
-    <script defer type='text/javascript' src='{% static 'game/js/foundation/foundation.min.js' %}'></script>
-    <script defer type='text/javascript' src='{% static 'game/js/handlebars.runtime-v3.0.3.js' %}'></script>
-    <script defer type='text/javascript' src='{% static 'game/js/templates.js' %}'></script>
-    <script defer type='text/javascript' src='{% static 'game/js/button.js' %}'></script>
+    <script type='text/javascript' src='{% static 'game/js/foundation/vendor/jquery.cookie.js' %}'></script>
+    <script type='text/javascript' src='{% static 'game/js/foundation/foundation.min.js' %}'></script>
+    <script type='text/javascript' src='{% static 'game/js/handlebars.runtime-v3.0.3.js' %}'></script>
+    <script type='text/javascript' src='{% static 'game/js/templates.js' %}'></script>
+    <script type='text/javascript' src='{% static 'game/js/button.js' %}'></script>
 {% endcompress %}
-    <script defer type='text/javascript' src='{% url 'js-reverse' %}'></script>
-    <script defer type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
+    <script type='text/javascript' src='{% url 'js-reverse' %}'></script>
+    <script type='text/javascript' src='{% url 'rapid-router/javascript-catalog' %}'></script>
 {% endblock %}

--- a/game/templates/game/game.html
+++ b/game/templates/game/game.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load i18n %}
 {% load game.utils %}
+{% load compress %}
 
 {% block scripts %}
 {{block.super}}
@@ -75,7 +76,7 @@
     var PYTHON_WORKSPACE = {% if python_workspace == None %}null{% else %}"{{python_workspace|linebreaksbr}}"{% endif %};
   </script>
 
-
+{% compress js file game %}
   <script defer type="text/javascript" src="{% static 'game/js/utils.js' %}"></script>
   <script defer type="text/javascript" src="{% static 'game/js/skulpt/skulpt.min.js' %}"></script>
   <script defer type="text/javascript" src="{% static 'game/js/skulpt/skulpt-stdlib.js' %}"></script>
@@ -125,15 +126,17 @@
       //FPSMeter.run(0.5);
     });
   </script>
-
+{% endcompress %}
 {% endblock %}
 
 {% block css %}
+{% compress css file game %}
 {{block.super}}
     <link href="{% static 'game/css/game.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'game/css/game_screen.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'game/css/skulpt/codemirror.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'game/css/skulpt/eclipse.css' %}" rel="stylesheet" type="text/css">
+{% endcompress %}
 {% endblock %}
 
 {% block content %}
@@ -239,14 +242,6 @@
         <span>{% trans "Help" %}</span>
       </label>
     </div>
-
-    <!--div class="tab">
-      <input type="radio" name="tabs" id="big_code_mode_radio">
-      <label for="big_code_mode_radio">
-        <img src='{% static "game/image/icons/big_code_mode.svg" %}'>
-        <span>Enlarge</span>
-      </label>
-    </div-->
 
     <div id="mute_tab" class="tab">
       <input type="radio" name="tabs" id="mute_radio">

--- a/game/templates/game/level_editor.html
+++ b/game/templates/game/level_editor.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load app_tags %}
 {% load game.utils %}
+{% load compress %}
 
 {% block title %}Code for Life - Rapid Router - Create{% endblock %}
 
@@ -17,6 +18,7 @@
     var COW_LEVELS_ENABLED = {{cow_level_enabled|booltojs}};
     var NIGHT_MODE_FEATURE_ENABLED = {{night_mode_feature_enabled}};
   </script>
+{% compress js %}
   <script src="{% static "game/js/utils.js" %}"></script>
   <script src="{% static "game/js/mobile-detect.min.js" %}"></script>
   <script src="{% static "game/js/raphael.js" %}"></script>
@@ -28,24 +30,26 @@
   <script type="text/javascript" src="{% static 'game/js/blockly/blocks_compressed.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/blockly/msg/js/en.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/mobile-detect.min.js' %}"></script>
-
   <script type="text/javascript" src="{% static 'game/js/blocklyCustomBlocks.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/blocklyControl.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/blocklyMessages.js' %}"></script>
+{% endcompress %}
 
-  <script src="/static/game/js/tab.js"></script>
-  <script src="/static/game/js/messages.js"></script>
-  <script src="/static/game/js/saving.js"></script>
-  <script src="/static/game/js/level_editor/level_save_state.js"></script>
-  <script src="/static/game/js/level_editor/owned_levels.js"></script>
-  <script src="/static/game/js/level_editor.js"></script>
-  <script src="/static/game/js/coordinate.js"></script>
-  <script src="/static/game/js/node.js"></script>
-  <script src="/static/game/js/map.js"></script>
-  <script src="/static/game/js/pathFinder.js"></script>
-  <script src="/static/game/js/trafficLight.js"></script>
-  {% if cow_level_enabled %}<script src="/static/game/js/cow.js"></script>{% endif %}
-  <script src="/static/game/js/destination.js"></script>
+{% compress js %}
+  <script src="{% static 'game/js/tab.js' %}"></script>
+  <script src="{% static 'game/js/messages.js' %}"></script>
+  <script src="{% static 'game/js/saving.js' %}"></script>
+  <script src="{% static 'game/js/level_editor/level_save_state.js' %}"></script>
+  <script src="{% static 'game/js/level_editor/owned_levels.js' %}"></script>
+  <script src="{% static 'game/js/level_editor.js' %}"></script>
+  <script src="{% static 'game/js/coordinate.js' %}"></script>
+  <script src="{% static 'game/js/node.js' %}"></script>
+  <script src="{% static 'game/js/map.js' %}"></script>
+  <script src="{% static 'game/js/pathFinder.js' %}"></script>
+  <script src="{% static 'game/js/trafficLight.js' %}"></script>
+  <script src="{% static 'game/js/destination.js' %}"></script>
+{% endcompress %}
+  {% if cow_level_enabled %}<script src="{% static 'game/js/cow.js' %}"></script>{% endif %}
 
   <script>
     var BLOCKS = [];
@@ -106,9 +110,11 @@
 {% endblock %}
 
 {% block css %}
+{% compress css %}
 {{ block.super }}
   <link href="{% static "game/css/game_screen.css" %}" rel="stylesheet" type="text/css">
   <link href="{% static "game/css/level_editor.css" %}" rel="stylesheet" type="text/css">
+{% endcompress %}
 {% endblock %}
 
 {% block content %}

--- a/game/templates/game/level_editor.html
+++ b/game/templates/game/level_editor.html
@@ -30,6 +30,7 @@
   <script type="text/javascript" src="{% static 'game/js/blockly/blocks_compressed.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/blockly/msg/js/en.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/mobile-detect.min.js' %}"></script>
+
   <script type="text/javascript" src="{% static 'game/js/blocklyCustomBlocks.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/blocklyControl.js' %}"></script>
   <script type="text/javascript" src="{% static 'game/js/blocklyMessages.js' %}"></script>
@@ -47,9 +48,9 @@
   <script src="{% static 'game/js/map.js' %}"></script>
   <script src="{% static 'game/js/pathFinder.js' %}"></script>
   <script src="{% static 'game/js/trafficLight.js' %}"></script>
-  <script src="{% static 'game/js/destination.js' %}"></script>
 {% endcompress %}
   {% if cow_level_enabled %}<script src="{% static 'game/js/cow.js' %}"></script>{% endif %}
+  <script src="{% static 'game/js/destination.js' %}"></script>
 
   <script>
     var BLOCKS = [];
@@ -110,8 +111,8 @@
 {% endblock %}
 
 {% block css %}
-{% compress css %}
 {{ block.super }}
+{% compress css %}
   <link href="{% static "game/css/game_screen.css" %}" rel="stylesheet" type="text/css">
   <link href="{% static "game/css/level_editor.css" %}" rel="stylesheet" type="text/css">
 {% endcompress %}

--- a/game/templates/game/level_moderation.html
+++ b/game/templates/game/level_moderation.html
@@ -1,15 +1,18 @@
 {% extends 'game/base.html' %}
 {% load static %}
 {% load i18n %}
+{% load compress %}
 
 {% block title %}Code for Life - Rapid Router - Level moderation{% endblock %}
 
 {% block scripts %}
 {{block.super}}
+{% compress js %}
 <script src="{% static 'game/js/jquery.tablesorter.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'game/js/saving.js' %}"></script>
 <script type="text/javascript" src="{% static 'game/js/level_moderation.js' %}"></script>
 <script type="text/javascript" src="{% static 'game/js/foundation/vendor/jquery.cookie.js' %}"></script>
+{% endcompress %}
 <script>
     var students = {% if students %} true {% else %} false {% endif %};
 </script>

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "docutils==0.12",
         "pyhamcrest==1.8.3",
         "libsass",
+        "django-compressor==2.3",
     ],
     tests_require=["django-selenium-clean==0.2.1", "selenium==3.7.0"],
     test_suite="test_utils.test_suite.DjangoAutoTestSuite",

--- a/test_settings.py
+++ b/test_settings.py
@@ -8,8 +8,17 @@ SELENIUM_WEBDRIVERS = {
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 
-INSTALLED_APPS = ["game"]
+STATICFILES_FINDERS = (
+    'compressor.finders.CompressorFinder',
+)
+
+INSTALLED_APPS = [
+    "game",
+    "compressor"
+]
 PIPELINE_ENABLED = False
+
+COMPRESS_ENABLED = True
 
 ROOT_URLCONF = "example_project.example_project.urls"
 STATIC_ROOT = os.path.join(

--- a/test_settings.py
+++ b/test_settings.py
@@ -8,9 +8,6 @@ SELENIUM_WEBDRIVERS = {
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 
-STATICFILES_FINDERS = (
-    'compressor.finders.CompressorFinder',
-)
 
 INSTALLED_APPS = [
     "game",
@@ -18,11 +15,15 @@ INSTALLED_APPS = [
 ]
 PIPELINE_ENABLED = False
 
-COMPRESS_ENABLED = True
+COMPRESS_ENABLED = False
 
 ROOT_URLCONF = "example_project.example_project.urls"
 STATIC_ROOT = os.path.join(
     os.path.dirname(__file__), "example_project/example_project", "static"
+)
+STATIC_URL = '/static/'
+STATICFILES_FINDERS = (
+    'compressor.finders.CompressorFinder',
 )
 SECRET_KEY = "test"
 


### PR DESCRIPTION
## Description
Add `django-compressor` to compress static js and css files to minimize http calls and slightly reduce resource size as well. This relates to #703 but is not yet complete. I will also do this on the portal and look at adding service workers.

## How Has This Been Tested?
I tested manually by navigating to all pages to make sure there were no errors.

## Screenshots (if appropriate):

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1059)
<!-- Reviewable:end -->
