### PR TITLE
fix: Install master branch of portal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         - pip install -U setuptools
         - pip install pipenv
         - pipenv install --dev --system
-        - pip install git+https://github.com/ocadotechnology/codeforlife-portal.git@upgrade_to_django_1_11#egg=codeforlife-portal #TODO: Remove as part of #688
+        - pip install git+https://github.com/ocadotechnology/codeforlife-portal.git#egg=codeforlife-portal #TODO: Remove as part of #688
         - pip install crowdin-cli-py
         - pip install selenium==3.14.0
         - pip install pytest-cov
@@ -51,7 +51,7 @@ jobs:
         - pip install -U setuptools
         - pip install pipenv
         - pipenv install --dev --system
-        - pip install git+https://github.com/ocadotechnology/codeforlife-portal.git@upgrade_to_django_1_11#egg=codeforlife-portal #TODO: Remove as part of #688
+        - pip install git+https://github.com/ocadotechnology/codeforlife-portal.git#egg=codeforlife-portal #TODO: Remove as part of #688
         - pip install crowdin-cli-py
       script:
         - mkdir -p game/locale


### PR DESCRIPTION
## Description
This PR installs the master branch of portal instead of the now deleted upgrade to Django 1.11 branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1071)
<!-- Reviewable:end -->
