### PR TITLE
fix: Remove django-appconf

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -23,6 +23,13 @@
             ],
             "version": "==1.11.24"
         },
+        "django-appconf": {
+            "hashes": [
+                "sha256:3d9bc963d8008ae151d6c664f9fd55442705ea9b9e6d7ce77cdd40bf92d91f3a",
+                "sha256:ba1375fb1024e8e91547504d4392321795c989fde500b96ebc7c93884f786e60"
+            ],
+            "version": "==1.0.1"
+        },
         "django-autoconfig": {
             "hashes": [
                 "sha256:5f28cfb7d848d9d99eadba62848732931c799cd9c98dc9792875e16ffcb1f700",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -23,13 +23,6 @@
             ],
             "version": "==1.11.24"
         },
-        "django-appconf": {
-            "hashes": [
-                "sha256:3d9bc963d8008ae151d6c664f9fd55442705ea9b9e6d7ce77cdd40bf92d91f3a",
-                "sha256:ba1375fb1024e8e91547504d4392321795c989fde500b96ebc7c93884f786e60"
-            ],
-            "version": "==1.0.1"
-        },
         "django-autoconfig": {
             "hashes": [
                 "sha256:5f28cfb7d848d9d99eadba62848732931c799cd9c98dc9792875e16ffcb1f700",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         "django-js-reverse==0.9.1",
         "django-foundation-statics==5.4.7",
         "django-pipeline==1.6.14",
-        "django-appconf==1.0.1",
         "django-casper==0.0.3",
         "djangorestframework>=3.8.2, <3.9.0",
         "six==1.11.0",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "django-js-reverse==0.9.1",
         "django-foundation-statics==5.4.7",
         "django-pipeline==1.6.14",
+        "django-appconf==1.0.1",
         "django-casper==0.0.3",
         "djangorestframework>=3.8.2, <3.9.0",
         "six==1.11.0",


### PR DESCRIPTION
## Description
This PR removes django-appconf as it is not used.

## How Has This Been Tested?
Ran tests locally and they all pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1076)
<!-- Reviewable:end -->
