### PR TITLE
fix: Remove django-casper

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -38,13 +38,6 @@
             ],
             "version": "==3.1.8"
         },
-        "django-casper": {
-            "hashes": [
-                "sha256:7659125168acdf77a8c93dec63f54c57c0295b77e353f4c3ac70aa0b7cfbc42b",
-                "sha256:d3dd4a9a0b267e1b5636ce25ba8be15b2423038bb4bb084734b264e06ef8c011"
-            ],
-            "version": "==0.0.3"
-        },
         "django-foundation-icons": {
             "hashes": [
                 "sha256:eba9bbce3c1a5cb3489aeed7158886826e5a9966cedd1f0d838bd588e43996bd"
@@ -123,12 +116,7 @@
         },
         "pyhamcrest": {
             "hashes": [
-                "sha256:0f88c8e7d8855853f8d6b7bf685478676f03049787ec1c31cf39764be0675450",
-                "sha256:118c48351451ec027cceed781841c19b836739e21f71a26649fe97fca0d346d5",
-                "sha256:6774ba8cdb0e98ed236368be47d20b123bd901aa0353275ff15f0d544aed1a45",
-                "sha256:83e00ee20b5cbd08c73faafc9e260bdd9dee5f69f9d59d6da5b9893c76187f38",
-                "sha256:97e2bc4499ed05eb29a4566338848227dcf1430e82d278bebe318565f6819189",
-                "sha256:bfe2e3154ec206ac7b6d36c0a4332879aba3f8637ca8b7005df83ffc22c20925"
+                "sha256:118c48351451ec027cceed781841c19b836739e21f71a26649fe97fca0d346d5"
             ],
             "version": "==1.8.3"
         },
@@ -233,7 +221,7 @@
                 "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db",
                 "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
             ],
-            "markers": "python_version < '3.4'",
+            "markers": "python_version < '3.6'",
             "version": "==2.3.5"
         },
         "pluggy": {
@@ -311,13 +299,6 @@
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
-        },
-        "sqlparse": {
-            "hashes": [
-                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
-                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
-            ],
-            "version": "==0.3.0"
         },
         "urllib3": {
             "hashes": [

--- a/game/tests/test_level_editor.py
+++ b/game/tests/test_level_editor.py
@@ -78,6 +78,7 @@ class LevelEditorTestCase(TestCase):
                 "login-teacher_email": email,
                 "login-teacher_password": password,
                 "login": "",
+                "g-recaptcha-response": "something",
             },
             follow=True,
         )
@@ -90,6 +91,7 @@ class LevelEditorTestCase(TestCase):
                 "login-access_code": access_code,
                 "login-password": password,
                 "school_login": "",
+                "g-recaptcha-response": "something",
             },
             follow=True,
         )

--- a/game/tests/test_level_moderation.py
+++ b/game/tests/test_level_moderation.py
@@ -100,6 +100,7 @@ class LevelModerationTestCase(TestCase):
                 "login-teacher_email": email,
                 "login-teacher_password": password,
                 "login": "",
+                "g-recaptcha-response": "something",
             },
             follow=True,
         )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         "django-js-reverse==0.9.1",
         "django-foundation-statics==5.4.7",
         "django-pipeline==1.6.14",
-        "django-casper==0.0.3",
         "djangorestframework>=3.8.2, <3.9.0",
         "six==1.11.0",
         "more-itertools==5.0.0",


### PR DESCRIPTION
## Description
This PR removes django-casper from the dependencies.

## How Has This Been Tested?
Ran tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1080)
<!-- Reviewable:end -->
