### PR TITLE
fix: remove Django foundation icons

### DIFF
--- a/game/autoconfig.py
+++ b/game/autoconfig.py
@@ -68,7 +68,6 @@ SETTINGS = {
         "django.contrib.staticfiles",
         "django_js_reverse",
         "foundation_scss",
-        "foundation_icons",
         "rest_framework",
     ],
     "LANGUAGES": [("lol-us", "Localisation")],

--- a/game/static/game/sass/game.scss
+++ b/game/static/game/sass/game.scss
@@ -37,7 +37,6 @@ identified as the original program.
 @import 'foundation_overrides';
 @import '../../scss/foundation';
 @import 'variables';
-@import '../../foundation-icons.scss';
 
 .size-12 { font-size: 12px; }
 
@@ -305,32 +304,6 @@ identified as the original program.
 
 .nuit-breadcrumbs {
   margin-bottom: 0.5em;
-}
-
-.alert-box {
-  &:before {
-    padding-right: 0.5em;
-  }
-  &.debug {
-    @include alert(
-      $bg: $iron
-    );
-    &:before {
-      @extend .fi-widget:before;
-    }
-  }
-  &.info:before {
-    @extend .fi-star:before;
-  }
-  &.success:before {
-    @extend .fi-check:before;
-  }
-  &.warning:before {
-    @extend .fi-alert:before;
-  }
-  &.alert:before {
-    @extend .fi-prohibited:before;
-  }
 }
 
 .responsive {

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "django>=1.10.8, <= 1.11.24",
-        "django-foundation-icons==3.1",
         "django-autoconfig >= 0.3.6, < 1.0.0",
         "django-js-reverse==0.9.1",
         "django-foundation-statics==5.4.7",


### PR DESCRIPTION
<!--- Follow the spec: https://www.conventionalcommits.org/en/v1.0.0-beta.3/#specification for the PR title and description -->
<!--- List any breaking changes here with the prefix BREAKING CHANGE: -->

<!--- This template can be modified slighty to the needs of the pull request -->

## Description
<!--- Describe your changes in detail -->
Removed foundation icons and statics as they seem to be unused dead code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Visually, manually tested
- Ran tests

## Screenshots (if appropriate):

## Checklist:
<!--- These can be used to show you've met the issue criteria, or similar. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1083)
<!-- Reviewable:end -->
