### PR TITLE
fix: Use Python 3 in Dockerfile (#1105)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14-stretch
+FROM python:3.7-slim-stretch@sha256:fdded80ae770ada550d33964ea383696c44548f76cbf4b07c4b4743a8e4a1045
 
 
 # install python 2.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.7-slim-stretch@sha256:fdded80ae770ada550d33964ea383696c44548f76cbf4b07c4b4743a8e4a1045
 
-
-# install python 2.7
 RUN apt-get update -yqq \
   && apt-get install -yqq ruby python-pip \
   && rm -rf /var/lib/apt/lists


### PR DESCRIPTION
## Description

f-string syntax is only valid in Python 3 but Dockerfile was using Python 2.
Added a shasum in case the image tag gets updated and breaks things

Fixes #1105  
## How Has This Been Tested?
I ran `docker-compose up` locally and checked localhost:8000 opened the site.

## Screenshots (if appropriate):

## Checklist:
<!--- These can be used to show you've met the issue criteria, or similar. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1111)
<!-- Reviewable:end -->
