### PR TITLE
fix: issue where a solution is shorter than model solution

### DIFF
--- a/game/static/game/js/pathFinder.js
+++ b/game/static/game/js/pathFinder.js
@@ -144,16 +144,15 @@ ocargo.PathFinder.prototype.getTravelledPathScore = function() {
 ocargo.PathFinder.prototype.getScoreForNumberOfInstructions = function() {
 
     var blocksUsed = ocargo.utils.isIOSMode() ? ocargo.game.mobileBlocks : ocargo.blocklyControl.activeBlocksCount();
-    var algorithmScore = 0;
-    var difference = this.maxScoreForNumberOfInstructions;
-    for (var i = 0; i < this.modelSolution.length; i++) {
-        var currDifference = blocksUsed - this.modelSolution[i];
-        if (Math.abs(currDifference) < difference) {
-            difference = Math.abs(currDifference);
-            algorithmScore = this.maxScoreForNumberOfInstructions - currDifference;
-        }
+    var algorithmScore = this.maxScoreForNumberOfInstructions;
+
+    var longestOfModelSolns = Math.max(...this.modelSolution);
+    var difference = blocksUsed - longestOfModelSolns;
+    if (difference > 0) {
+      algorithmScore = algorithmScore - difference;
     }
     return algorithmScore;
+    // return 10;
 };
 
 ocargo.PathFinder.prototype.getLength = function(stack) {

--- a/game/static/game/js/pathFinder.js
+++ b/game/static/game/js/pathFinder.js
@@ -152,7 +152,6 @@ ocargo.PathFinder.prototype.getScoreForNumberOfInstructions = function() {
       algorithmScore = algorithmScore - difference;
     }
     return algorithmScore;
-    // return 10;
 };
 
 ocargo.PathFinder.prototype.getLength = function(stack) {


### PR DESCRIPTION
#1123 - fix for issue where the solution is more concise than the model

## Description
pathFinder.js :: getScoreForNumberOfInstructions changed to allow for when player's solution is shorter than the model solution.

## How Has This Been Tested?
* Unit tests run.
* Procedure given in #1123 

## Screenshots (if appropriate):

## Checklist:
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ / ] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1125)
<!-- Reviewable:end -->
