### PR TITLE
fix: Messages for Level 39 so that students are not encouraged to use if

### DIFF
--- a/game/messages.py
+++ b/game/messages.py
@@ -1097,19 +1097,18 @@ def title_level39():
 
 def description_level39():
     message = ugettext(
-        "Can you change the 'general algorithm' so that the van takes a shorter "
-        + "route? <br> What if you change the order the van checks for "
-        + "directions? <br> Keep an eye on the fuel level - try to use as "
-        + "little as possible. "
+        "Can you use the 'general algorithm' here so that the van takes a "
+        + "shorter route? Or maybe there's a more efficient way? <br><br>Keep "
+        + "an eye on the fuel level - try to use as little as possible."
     )
     return build_description(title_level39(), message)
 
 
 def hint_level39():
     message = ugettext(
-        "Make the van check if the road exists right before it checks if the road "
-        + "exists left. <br><br> Then it will be able to reach the destination "
-        + "using the 'general algorithm'. Can you see why? "
+        "Uh oh, moving around the blocks in your 'general algorithm' might not "
+        + "be the most efficient solution. How about creating a simple solution "
+        + "without 'if statements' that will help the van reach the house? "
     )
     return message
 


### PR DESCRIPTION
## Description
fixes #705 The messages for Level 39 are updated in accordance with https://app.zenhub.com/workspaces/code-for-life-development-56f2afba6e54555c586f6db3/issues/ocadotechnology/rapid-router/705#issuecomment-643151943.   

## How Has This Been Tested?
Test suite still runs, visual inspection of messages.

- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ / ] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1129)
<!-- Reviewable:end -->
