### PR TITLE
fix: Use correct token for publishing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,32 +2,34 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
 jobs:
-  build:
+  tests:
+    name: Run tests
+    if: ${{ github.event.pusher.name != 'actions-user' }}
     runs-on: ubuntu-18.04
     env:
       LANG: C.UTF-8
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.6.7'
-        architecture: 'x64'
-    - name: Install pip requirements
-      run: |
-        pip install pipenv
-        pip install pytest-cov
-        pipenv install --dev --system
-        pip install -U git+https://github.com/ocadotechnology/codeforlife-portal.git#egg=codeforlife-portal #TODO: Remove as part of #688
-    - name: Collect static
-      run: python example_project/manage.py collectstatic --noinput
-    - name: Run tests
-      env:
-        SELENIUM_WEBDRIVER: chrome-headless
-      run: pytest --cov=. --cov-report=xml
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6.7'
+          architecture: 'x64'
+      - name: Install pip requirements
+        run: |
+          pip install pipenv
+          pip install pytest-cov
+          pipenv install --dev --system
+          pip install -U git+https://github.com/ocadotechnology/codeforlife-portal.git#egg=codeforlife-portal #TODO: Remove as part of #688
+      - name: Collect static
+        run: python example_project/manage.py collectstatic --noinput
+      - name: Run tests
+        env:
+          SELENIUM_WEBDRIVER: chrome-headless
+        run: pytest --cov=. --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -1,16 +1,15 @@
 name: Publish Python Package
 on:
-  push:
-  # pull_request:
-  # workflow_run:
-  #   workflows: ['CI']
-  #   branches: [master]
-  #   types:
-  #     - completed
+  pull_request:
+  workflow_run:
+    workflows: ['CI']
+    branches: [master]
+    types:
+      - completed
 jobs:
   publish-pypi-packages:
     name: Publish PyPi Packages
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish-pypi-packages:
     name: Publish PyPi Packages
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -1,11 +1,12 @@
 name: Publish Python Package
 on:
-  pull_request:
-  workflow_run:
-    workflows: ['CI']
-    branches: [master]
-    types:
-      - completed
+  push:
+  # pull_request:
+  # workflow_run:
+  #   workflows: ['CI']
+  #   branches: [master]
+  #   types:
+  #     - completed
 jobs:
   publish-pypi-packages:
     name: Publish PyPi Packages

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
       - name: Setup Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
I have also neatened up the GitHub actions ci.yml file so that the job has a more semantic name and won't run on "semantic-release" commits

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1139)
<!-- Reviewable:end -->
