### PR TITLE
fix: fix translation files owner

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -40,6 +40,8 @@ jobs:
           push_translations: false
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
           token: ${{ secrets.CROWDIN_API_KEY }}
+      - name: Fix translation files owner
+        run: sudo chown -R $USER game/locale
       - name: Compile messages
         run: |
           pushd game


### PR DESCRIPTION
<!--- Follow the spec: https://www.conventionalcommits.org/en/v1.0.0-beta.3/#specification for the PR title and description -->
<!--- List any breaking changes here with the prefix BREAKING CHANGE: -->

<!--- This template can be modified slighty to the needs of the pull request -->

## Description
<!--- Describe your changes in detail -->
In Publish action, "Run Crowdin" step will download translations in a docker container which runs as root. We need to update these permissions to the current user to be able to use translations in the next step.

## Checklist:
<!--- These can be used to show you've met the issue criteria, or similar. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Compile messages step in publish action should pass after PR is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1149)
<!-- Reviewable:end -->
