### PR TITLE
feat: check cookie consent when muting game

### DIFF
--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -43,6 +43,7 @@ ocargo.Game = function () {
   this.tabs = null
   this.failures = 0
   this.currentlySelectedTab = null
+  this.isMuted = $.cookie('muted') === 'true'
 }
 
 ocargo.Game.prototype.setup = function () {
@@ -476,13 +477,18 @@ ocargo.Game.prototype.onSlowControls = function () {
 }
 
 ocargo.Game.prototype.mute = function (mute) {
+  this.isMuted = mute
   if (mute) {
     ocargo.sound.mute()
-    $.cookie('muted', 'true', { path: Urls.levels() })
+    if (hasFunctionalCookiesConsent()) {
+      $.cookie('muted', 'true', { path: Urls.levels() })
+    }
     this.tabs.mute.transitTo('muted')
   } else {
     ocargo.sound.unmute()
-    $.cookie('muted', 'false', { path: Urls.levels() })
+    if (hasFunctionalCookiesConsent()) {
+      $.cookie('muted', 'false', { path: Urls.levels() })
+    }
     this.tabs.mute.transitTo('unmuted')
   }
 }
@@ -1147,7 +1153,7 @@ ocargo.Game.prototype._setupHelpTab = function () {
 ocargo.Game.prototype._setupMuteTab = function () {
   this.tabs.mute.setOnChange(
     function () {
-      this.mute($.cookie('muted') !== 'true')
+      this.mute(!this.isMuted)
       this._selectPreviousTab()
     }.bind(this)
   )
@@ -1219,8 +1225,12 @@ function restoreCmsLogin () {
     .css('display', 'inline')
 }
 
+function hasFunctionalCookiesConsent() {
+  return OnetrustActiveGroups && OnetrustActiveGroups.split(',').includes('C0003')
+}
+
 $(document).ready(function () {
   ocargo.game = new ocargo.Game()
   ocargo.game.setup()
-  ocargo.game.mute($.cookie('muted') === 'true')
+  ocargo.game.mute(ocargo.game.isMuted)
 })

--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -478,17 +478,12 @@ ocargo.Game.prototype.onSlowControls = function () {
 
 ocargo.Game.prototype.mute = function (mute) {
   this.isMuted = mute
+  setMutedCookie(mute)
   if (mute) {
     ocargo.sound.mute()
-    if (hasFunctionalCookiesConsent()) {
-      $.cookie('muted', 'true', { path: Urls.levels() })
-    }
     this.tabs.mute.transitTo('muted')
   } else {
     ocargo.sound.unmute()
-    if (hasFunctionalCookiesConsent()) {
-      $.cookie('muted', 'false', { path: Urls.levels() })
-    }
     this.tabs.mute.transitTo('unmuted')
   }
 }
@@ -1227,6 +1222,12 @@ function restoreCmsLogin () {
 
 function hasFunctionalCookiesConsent() {
   return OnetrustActiveGroups && OnetrustActiveGroups.split(',').includes('C0003')
+}
+
+function setMutedCookie(mute) {
+  if (hasFunctionalCookiesConsent()) {
+    $.cookie('muted', mute.toString(), { path: Urls.levels() })
+  }
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
## Description
When muting the game, the cookie should only be set if the user gave consent for functional cookies. Muting the game should still work, but the status won't be saved on page reload or other levels if the cookie is not set.

## How Has This Been Tested?
1. Change cookie settings to allow functional cookies, then mute the game and either refresh the page or go to another level. The game should still be muted.
2. Change cookie settings to disallow functional cookies, then mute the game and either refresh the page or go to another level. The game should not be muted anymore as the status has not been saved. However, toggling the mute button should work while on the page (until reloading).

## Checklist:
- [ ] Game mute status should be saved if the user gives functional cookies consent.
- [ ] Game mute status should not be saved otherwise.
- [ ] Game mute feature should still work in any case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1157)
<!-- Reviewable:end -->
