### PR TITLE
fix: set location of trash can on first render

### DIFF
--- a/game/static/game/js/level_editor.js
+++ b/game/static/game/js/level_editor.js
@@ -1231,37 +1231,42 @@ ocargo.LevelEditor = function() {
     /* Trashcan */
     /************/
 
+    function placeTrashcan(trashcan) {
+        // Iffy way of making sure the trashcan stays inside the grid
+        // when window bigger than grid
+        var windowWidth = $(window).width();
+        var windowHeight = $(window).height();
+
+        var paperRightEdge = PAPER_WIDTH + $('#tools').width();
+        var paperBottomEdge = PAPER_HEIGHT;
+
+        var bottom = 50;
+        if(windowHeight > paperBottomEdge) {
+            bottom += windowHeight - paperBottomEdge
+        }
+
+        var right = 50;
+        if(windowWidth > paperRightEdge) {
+            right += windowWidth - paperRightEdge;
+        }
+
+        trashcan.css('right', right);
+        trashcan.css('bottom', bottom);
+
+        var trashcanOffset = trashcan.offset();
+        var paperOffset = paper.offset();
+        trashcanAbsolutePaperX = trashcanOffset.left - paperOffset.left;
+        trashcanAbsolutePaperY = trashcanOffset.top - paperOffset.top;
+    }
+
     function setupTrashcan() {
 
         var trashcan = $('#trashcanHolder');
 
-        // Iffy way of making sure the trashcan stays inside the grid
-        // when window bigger than grid
+        placeTrashcan(trashcan);
+
         $(window).resize(function() {
-            var windowWidth = $(window).width();
-            var windowHeight = $(window).height();
-
-            var paperRightEdge = PAPER_WIDTH + $('#tools').width();
-            var paperBottomEdge = PAPER_HEIGHT;
-
-            var bottom = 50;
-            if(windowHeight > paperBottomEdge) {
-                bottom += windowHeight - paperBottomEdge
-            }
-
-            var right = 50;
-            if(windowWidth > paperRightEdge) {
-                right += windowWidth - paperRightEdge;
-            }
-
-            trashcan.css('right', right);
-            trashcan.css('bottom', bottom);
-
-
-            var trashcanOffset = trashcan.offset();
-            var paperOffset = paper.offset();
-            trashcanAbsolutePaperX = trashcanOffset.left - paperOffset.left;
-            trashcanAbsolutePaperY = trashcanOffset.top - paperOffset.top;
+            placeTrashcan(trashcan);
         });
 
         addReleaseListeners(trashcan[0]);


### PR DESCRIPTION
<!--- Follow the spec: https://www.conventionalcommits.org/en/v1.0.0-beta.3/#specification for the PR title and description -->

## Description
This change fixes #1152 .  The function setUpTrashcan() in level_editor.js was previously only setting the location of the trash on a window resize.  This change ensures it is set also when the page is first loaded.

## How Has This Been Tested?
Manually, in Chrome 88.0.4324.146 on Ubuntu 20.04

## Screenshots (if appropriate):

On first load:
![Screenshot from 2021-02-05 13-03-55](https://user-images.githubusercontent.com/8608172/107051547-7c348600-67c4-11eb-8f33-22ef0bbd80e7.png)
On window resize:
![Screenshot from 2021-02-05 13-04-30](https://user-images.githubusercontent.com/8608172/107051630-9706fa80-67c4-11eb-8bc6-0b69e6c89d39.png)


## Checklist:
<!--- These can be used to show you've met the issue criteria, or similar. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1160)
<!-- Reviewable:end -->
