### PR TITLE
fix: disable saving and loading of workspace when user is not logged in

### DIFF
--- a/game/end_to_end_tests/base_game_test.py
+++ b/game/end_to_end_tests/base_game_test.py
@@ -78,6 +78,34 @@ class BaseGameTest(SeleniumTestCase):
             else:
                 break
 
+    def _complete_level(self, level_number, **kwargs):
+        page = self.go_to_level(level_number)
+        self.complete_and_check_level(level_number, page, **kwargs)
+
+    def complete_and_check_level(
+        self,
+        level_number,
+        page,
+        next_episode=None,
+        check_algorithm_score=True,
+        check_route_score=True,
+        final_level=False,
+    ):
+        page.solution_button().run_program().assert_success()
+        if check_algorithm_score:
+            page.assert_algorithm_score(10)
+        if check_route_score:
+            page.assert_route_score(10)
+        if final_level:
+            return page
+        if next_episode is None:
+            page.next_level()
+            page.assert_level_number(level_number + 1)
+        else:
+            page.next_episode()
+            page.assert_episode_number(next_episode)
+        return page
+
     def go_to_homepage(self):
         path = reverse("home")
         self._go_to_path(path)

--- a/game/end_to_end_tests/data/blockly_solutions/once_forwards.xml
+++ b/game/end_to_end_tests/data/blockly_solutions/once_forwards.xml
@@ -1,0 +1,8 @@
+<xml>
+    <block type="start" id="1" deletable="false" x="30" y="30">
+        <next>
+            <block type="move_forwards" id="2">
+            </block>
+        </next>
+    </block>
+</xml>

--- a/game/end_to_end_tests/test_level_failures.py
+++ b/game/end_to_end_tests/test_level_failures.py
@@ -35,7 +35,6 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 from game.end_to_end_tests.base_game_test import BaseGameTest
-from .test_play_through import complete_and_check_level
 
 
 class TestCrashes(BaseGameTest):
@@ -112,4 +111,4 @@ class TestCrashes(BaseGameTest):
             .clear()
         )
 
-        complete_and_check_level(6, page)
+        self.complete_and_check_level(6, page)

--- a/game/end_to_end_tests/test_level_win.py
+++ b/game/end_to_end_tests/test_level_win.py
@@ -35,7 +35,6 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 from game.end_to_end_tests.base_game_test import BaseGameTest
-from .test_play_through import complete_and_check_level
 
 
 class TestLevelWin(BaseGameTest):
@@ -46,4 +45,4 @@ class TestLevelWin(BaseGameTest):
         page = self.try_again_if_not_full_score_test(
             level=19, workspace_file="complete_level_not_with_full_score"
         )
-        complete_and_check_level(19, page)
+        self.complete_and_check_level(19, page)

--- a/game/end_to_end_tests/test_localstorage.py
+++ b/game/end_to_end_tests/test_localstorage.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# Code for Life
+#
+# Copyright (C) 2021, Ocado Innovation Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ADDITIONAL TERMS – Section 7 GNU General Public Licence
+#
+# This licence does not grant any right, title or interest in any “Ocado” logos,
+# trade names or the trademark “Ocado” or any other trademarks or domain names
+# owned by Ocado Innovation Limited or the Ocado group of companies or any other
+# distinctive brand features of “Ocado” as may be secured from time to time. You
+# must not distribute any modification of this program using the trademark
+# “Ocado” or claim any affiliation or association with Ocado or its employees.
+#
+# You are not authorised to use the name Ocado (or any of its trade names) or
+# the names of any author or contributor in advertising or for publicity purposes
+# pertaining to the distribution of this program, without the prior written
+# authorisation of Ocado.
+#
+# Any propagation, distribution or conveyance of this program must include this
+# copyright notice and these terms. You must not misrepresent the origins of this
+# program; modified versions of the program must be marked as such and not
+# identified as the original program.
+
+from django.urls.base import reverse
+from .base_game_test import BaseGameTest
+from selenium.webdriver.common.by import By
+
+
+class LocalStorage:
+    def __init__(self, driver):
+        self.driver = driver
+
+    def items(self):
+        items = self.driver.execute_script(
+            "var ls = window.localStorage, items = {}; "
+            "for (var i = 0, k; i < ls.length; ++i) "
+            "  items[k = ls.key(i)] = ls.getItem(k); "
+            "return items; "
+        )
+        return items
+
+    def clear(self):
+        try:
+            self.driver.execute_script("window.localStorage.clear();")
+        except Exception as e:
+            print(e)
+
+
+class TestLocalStorage(BaseGameTest):
+    def level_in_localstorage(self, level_number):
+        items = LocalStorage(self.selenium).items()
+        print(items)
+        return (f"blocklyWorkspaceXml-{level_number}" in items) and (
+            f"pythonWorkspace-{level_number}" in items
+        )
+
+    def test_localstorage_if_logged_in(self):
+        self.login_once()
+        self._complete_level(1)
+        self.assertTrue(self.level_in_localstorage(1))
+
+    def test_nothing_in_localstorage_if_not_logged_in(self):
+        page = self.go_to_homepage()
+        page.teacher_logout()
+
+        level1 = self.go_to_level(1)
+
+        ls = LocalStorage(self.selenium)
+        print("before clear")
+        print(ls.items())
+        ls.clear()
+        print("after clear")
+        print(ls.items())
+
+        solution = self.read_solution("once_forwards")
+        script = f"""
+            const xml = `{solution}`;
+            Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.textToDom(xml), Blockly.mainWorkspace);
+            """
+        self.selenium.execute_script(script)
+        self.selenium.find_element_by_id("fast_tab").click()
+
+        level1.wait_for_element_to_be_clickable((By.CSS_SELECTOR, "#next_level_button"))
+        print("before change page")
+        print(ls.items())
+        level1.next_level()
+        print("after change page")
+        print(ls.items())
+        self.assertFalse(self.level_in_localstorage(1))

--- a/game/end_to_end_tests/test_localstorage.py
+++ b/game/end_to_end_tests/test_localstorage.py
@@ -54,11 +54,7 @@ class LocalStorage:
         return items
 
     def clear(self):
-        try:
-            self.driver.execute_script("window.localStorage.clear();")
-        except Exception as e:
-            print(e)
-
+        self.driver.execute_script("window.localStorage.clear();")
 
 class TestLocalStorage(BaseGameTest):
     def level_in_localstorage(self, level_number):

--- a/game/end_to_end_tests/test_localstorage.py
+++ b/game/end_to_end_tests/test_localstorage.py
@@ -59,7 +59,6 @@ class LocalStorage:
 class TestLocalStorage(BaseGameTest):
     def level_in_localstorage(self, level_number):
         items = LocalStorage(self.selenium).items()
-        print(items)
         return (f"blocklyWorkspaceXml-{level_number}" in items) and (
             f"pythonWorkspace-{level_number}" in items
         )
@@ -76,11 +75,7 @@ class TestLocalStorage(BaseGameTest):
         level1 = self.go_to_level(1)
 
         ls = LocalStorage(self.selenium)
-        print("before clear")
-        print(ls.items())
         ls.clear()
-        print("after clear")
-        print(ls.items())
 
         solution = self.read_solution("once_forwards")
         script = f"""
@@ -91,9 +86,5 @@ class TestLocalStorage(BaseGameTest):
         self.selenium.find_element_by_id("fast_tab").click()
 
         level1.wait_for_element_to_be_clickable((By.CSS_SELECTOR, "#next_level_button"))
-        print("before change page")
-        print(ls.items())
         level1.next_level()
-        print("after change page")
-        print(ls.items())
         self.assertFalse(self.level_in_localstorage(1))

--- a/game/end_to_end_tests/test_play_through.py
+++ b/game/end_to_end_tests/test_play_through.py
@@ -34,33 +34,8 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-from unittest import expectedFailure, skip
 
 from .base_game_test import BaseGameTest
-
-
-def complete_and_check_level(
-    level_number,
-    page,
-    next_episode=None,
-    check_algorithm_score=True,
-    check_route_score=True,
-    final_level=False,
-):
-    page.solution_button().run_program().assert_success()
-    if check_algorithm_score:
-        page.assert_algorithm_score(10)
-    if check_route_score:
-        page.assert_route_score(10)
-    if final_level:
-        return page
-    if next_episode is None:
-        page.next_level()
-        page.assert_level_number(level_number + 1)
-    else:
-        page.next_episode()
-        page.assert_episode_number(next_episode)
-    return page
 
 
 class TestPlayThrough(BaseGameTest):
@@ -69,11 +44,11 @@ class TestPlayThrough(BaseGameTest):
 
     def _complete_episode(self, episode_number, level_number, **kwargs):
         page = self.go_to_episode(episode_number)
-        complete_and_check_level(level_number, page, **kwargs)
+        self.complete_and_check_level(level_number, page, **kwargs)
 
     def _complete_level(self, level_number, **kwargs):
         page = self.go_to_level(level_number)
-        complete_and_check_level(level_number, page, **kwargs)
+        self.complete_and_check_level(level_number, page, **kwargs)
 
     def test_episode_01(self):
         self._complete_episode(1, 1)

--- a/game/static/game/js/blocklyControl.js
+++ b/game/static/game/js/blocklyControl.js
@@ -103,7 +103,7 @@ ocargo.BlocklyControl.prototype.reset = function() {
 
 
 ocargo.BlocklyControl.prototype.teardown = function() {
-    if (localStorage && !ANONYMOUS) {
+    if (localStorage && !ANONYMOUS && USER_LOGGED_IN) {
         var text = this.serialize();
         try {
             if (NIGHT_MODE) {

--- a/game/static/game/js/pythonControl.js
+++ b/game/static/game/js/pythonControl.js
@@ -128,7 +128,7 @@ ocargo.PythonControl = function () {
     };
 
     this.teardown = function () {
-        if (localStorage && !ANONYMOUS) {
+        if (localStorage && !ANONYMOUS && USER_LOGGED_IN) {
             var text = this.getCode();
             try {
                 localStorage.setItem('pythonWorkspace-' + LEVEL_ID, text);

--- a/game/templates/game/game.html
+++ b/game/templates/game/game.html
@@ -214,7 +214,7 @@
               <span>{% trans "Solve" %}</span>
           </label>
       </div>
-
+{% if request.user.is_authenticated %}
     <div id="load_tab"class="tab selectable">
       <input type="radio" name="tabs" id="load_radio">
       <label for="load_radio">
@@ -230,7 +230,7 @@
         <span>{% trans "Save" %}</span>
       </label>
     </div>
-
+{% endif %}
     <div class="tab_break"></div>
 
     <div id="help_tab" class="tab selectable">

--- a/game/templates/game/game.html
+++ b/game/templates/game/game.html
@@ -45,6 +45,7 @@
     var NIGHT_MODE_FEATURE_ENABLED = {{night_mode_feature_enabled}};
     var NIGHT_MODE = {{night_mode}};
     var FLIP_NIGHT_MODE_URL = "{{flip_night_mode_url|default:""}}";
+    var USER_LOGGED_IN = {{request.user.is_authenticated|booltojs}};
 
     var RANDOM = {{episode.random_levels_enabled|booltojs}};
     var IS_RANDOM_LEVEL = {{random_level|booltojs}};


### PR DESCRIPTION
## Description

- Disable browser local storage if the user is not logged in by passing logged in status to the blockly controller and python controller, which save to localstorage only if the user is logged in.  
- Disable save and load buttons in the game template when user is not logged by change to template
- Refactor base_game_test.py : move method complete_and_check level up from test_run_through.py

## How Has This Been Tested?
- Added new test file test_localstorage.py with 2 selenium tests: if logged in, data should be saved to localstorage, if not then not saved. These new tests include new test functionality that allow adding an xml solution to a workspace in Blockly.  - Tested by hand
- Verified that unit tests run (on MacOS 11.5.1 and Chrome Version 92.0.4515.131 (Official Build) (arm64)

## Screenshots (if appropriate):

## Checklist:
<!--- These can be used to show you've met the issue criteria, or similar. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ √ ] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1216)
<!-- Reviewable:end -->
