### PR TITLE
fix: 1099 cannot delete custom levels in level moderation page

### DIFF
--- a/game/static/game/css/level_moderation.css
+++ b/game/static/game/css/level_moderation.css
@@ -54,3 +54,4 @@ select {
 .btn {
 	margin: 0px
 }
+

--- a/game/static/game/css/level_moderation.css
+++ b/game/static/game/css/level_moderation.css
@@ -54,4 +54,3 @@ select {
 .btn {
 	margin: 0px
 }
-

--- a/game/static/game/css/level_selection.css
+++ b/game/static/game/css/level_selection.css
@@ -108,4 +108,3 @@ identified as the original program.
   content: "\e250";
   font-family: "Glyphicons Halflings";
 }
-

--- a/game/static/game/css/level_selection.css
+++ b/game/static/game/css/level_selection.css
@@ -108,3 +108,4 @@ identified as the original program.
   content: "\e250";
   font-family: "Glyphicons Halflings";
 }
+

--- a/game/static/game/js/level_moderation.js
+++ b/game/static/game/js/level_moderation.js
@@ -46,23 +46,7 @@ function csrfSafeMethod(method) {
 
 var saving = new ocargo.Saving();
 
-var CONFIRMATION_DATA = {
-    'deleteLevel': {
-        options: {
-            title: gettext('Delete level'),
-        },
-        html: '<p>' + gettext("This student's level will be permanently deleted. Are you sure?") + '</p>',
-        confirm: function() {
-            saving.deleteLevel(levelID,
-                function () {
-                    document.forms["levelModerationForm"].submit();
-                },
-                console.error);
-        }
-    }
-};
-
-function deleteLevel(e) {
+function deleteLevel() {
     saving.deleteLevel(levelID,
         function () {
             document.forms["levelModerationForm"].submit();
@@ -72,29 +56,26 @@ function deleteLevel(e) {
 
 function showPopupConfirmation(title, text, confirm_handler) {
     var popup = $(".popup-wrapper");
-    $(".popup-box__title").text('Delete level');
-    $(".popup-box__msg").append('<p>' + gettext("This student's level will be permanently deleted. Are you sure?") + '</p>');
-    console.log($("#confirm_button"));
-    $("#confirm_button").click(deleteLevel);
+    $(".popup-box__title").text(title);
+    $(".popup-box__msg").append(text);
+    $("#confirm_button").click(confirm_handler);
 
     popup.addClass("popup--fade");
 }
 
-function openConfirmationBox(type) {
-    var data = CONFIRMATION_DATA[type];
+function confirmDelete() {
+    console.log(levelID);
+    var title = 'Delete level';
+    var text = '<p>' + gettext("This student's level will be permanently deleted. Are you sure?") + '</p>';
 
-    var title = data.options.title;
-    var text = data.html;
-    var confirm_handler = data.confirm;
-
-    showPopupConfirmation(title, text, data.confirm);
-
+    showPopupConfirmation(title, text, deleteLevel);
 }
+
 $(document).ready(function() {
 	$(".delete").click(function() {
 
 	  	levelID = this.getAttribute('value');
-	  	openConfirmationBox('deleteLevel');
+	  	confirmDelete();
 	});
 
 	$('.play').click(function() {

--- a/game/static/game/js/level_moderation.js
+++ b/game/static/game/js/level_moderation.js
@@ -62,6 +62,34 @@ var CONFIRMATION_DATA = {
     }
 };
 
+function deleteLevel(e) {
+    saving.deleteLevel(levelID,
+        function () {
+            document.forms["levelModerationForm"].submit();
+        },
+        console.error);
+}
+
+function showPopupConfirmation(title, text, confirm_handler) {
+    var popup = $(".popup-wrapper");
+    $(".popup-box__title").text('Delete level');
+    $(".popup-box__msg").append('<p>' + gettext("This student's level will be permanently deleted. Are you sure?") + '</p>');
+    console.log($("#confirm_button"));
+    $("#confirm_button").click(deleteLevel);
+
+    popup.addClass("popup--fade");
+}
+
+function openConfirmationBox(type) {
+    var data = CONFIRMATION_DATA[type];
+
+    var title = data.options.title;
+    var text = data.html;
+    var confirm_handler = data.confirm;
+
+    showPopupConfirmation(title, text, data.confirm);
+
+}
 $(document).ready(function() {
 	$(".delete").click(function() {
 

--- a/game/templates/game/level_moderation.html
+++ b/game/templates/game/level_moderation.html
@@ -53,6 +53,7 @@
     </div>
 
     <div class="mainBody container">
+        {% include "portal/partials/popup.html" %}
         {% if levelData %}
         <div class="tableWrapper">
             {% if thead %}


### PR DESCRIPTION
<!--- Follow the spec: https://www.conventionalcommits.org/en/v1.0.0-beta.3/#specification for the PR title and description -->
<!--- List any breaking changes here with the prefix BREAKING CHANGE: -->

<!--- This template can be modified slighty to the needs of the pull request -->

## Description
<!--- Describe your changes in detail -->
Fix for #1099: no modal appeared when you select delete for a level in the level moderation page. Added the required element to the page and the javascript.  It looks as though this is the only place it is needed in RR so have kept it local to that page, and we can refactor if it is also needed elsewhere.  

## How Has This Been Tested?
Unit and end-to-end tests run.  No new tests added because it's a bug fix and functionality unchanged.  Verified by hand (Mac OS, Chrome 92)

## Screenshots (if appropriate):
<img width="1325" alt="Screenshot 2021-09-11 at 09 45 08" src="https://user-images.githubusercontent.com/8608172/132942182-b8eea08f-af28-410c-b4da-80494076363b.png">


## Checklist:
<!--- These can be used to show you've met the issue criteria, or similar. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ / ] I have linked this PR to a Zenhub Issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1229)
<!-- Reviewable:end -->
