### PR TITLE
fix: broken coin image for students in episode

### DIFF
--- a/game/end_to_end_tests/base_game_test.py
+++ b/game/end_to_end_tests/base_game_test.py
@@ -11,6 +11,7 @@ from common.tests.utils.teacher import signup_teacher_directly
 from django.test import TestCase
 from django.urls import reverse
 from portal.tests.pageObjects.portal.home_page import HomePage
+from portal.tests.pageObjects.portal.base_page import BasePage
 
 from game.models import Workspace
 from . import custom_handler
@@ -73,6 +74,11 @@ class BaseGameTest(SeleniumTestCase):
             page.next_episode()
             page.assert_episode_number(next_episode)
         return page
+
+    def go_to_reverse(self, url_reverse):
+        path = reverse(url_reverse)
+        self._go_to_path(path)
+        return BasePage(self.selenium)
 
     def go_to_homepage(self):
         path = reverse("home")

--- a/game/end_to_end_tests/test_level_selection.py
+++ b/game/end_to_end_tests/test_level_selection.py
@@ -1,0 +1,64 @@
+from common.tests.utils.classes import create_class_directly
+from common.tests.utils.organisation import create_organisation_directly
+from common.tests.utils.student import create_school_student_directly
+from common.tests.utils.teacher import signup_teacher_directly
+
+from hamcrest import assert_that, ends_with, equal_to
+
+from selenium.common.exceptions import NoSuchElementException
+
+from game.end_to_end_tests.base_game_test import BaseGameTest
+from game.models import Attempt, Episode
+
+
+class TestLevelSelection(BaseGameTest):
+    def test_coins(self):
+
+        # Set up student
+        email, password = signup_teacher_directly()
+        create_organisation_directly(email)
+        klass, name, access_code = create_class_directly(email)
+        name, password, student = create_school_student_directly(access_code)
+
+        # Student has perfect score for each level in an episode
+        episode = Episode.objects.get(name="Loops with Conditions")
+        for a_level in episode.levels:
+            attempt = Attempt(student=student, score=20.0, level=a_level)
+            attempt.save()
+
+        #  Student logs in
+        code_page = self.go_to_homepage().go_to_student_login_page()
+        student_login_page = code_page.student_input_access_code(access_code)
+        page = student_login_page.student_login(name, password)
+
+        # Goes to rapid router levels
+        page = self.go_to_reverse("levels")
+
+        # The coin images for the levels
+        level_coin_images = page.browser.find_elements_by_css_selector(
+            "#collapse-4 div img"
+        )
+        # There are 4 levels in this episode, each with gold coin
+        assert_that(len(level_coin_images), equal_to(4))
+
+        for image in level_coin_images:
+            assert_that(
+                image.get_attribute("src"),
+                ends_with("/static/game/image/coins/coin_gold.svg"),
+            )
+
+        # So the episode has a gold coin too
+        episode_coin_image = page.browser.find_element_by_css_selector(
+            "#episode-4 > p > img"
+        )
+        assert_that(
+            episode_coin_image.get_attribute("src"),
+            ends_with("/static/game/image/coins/coin_gold.svg"),
+        )
+
+        try:
+            image_for_uncomplete_episode = page.browser.find_element_by_css_selector(
+                "#episode-3 > p > img"
+            )
+        except NoSuchElementException as this_should_happen:
+            pass

--- a/game/static/game/css/level_selection.css
+++ b/game/static/game/css/level_selection.css
@@ -55,7 +55,7 @@
 #episodes .episode_image.coin_image {
   width: 30px;
   height: 30px;
-  margin-top: -6px;
+  margin-top: -3px;
 }
 
 #episodes .level_image.coin_image {

--- a/game/static/game/js/level_selection.js
+++ b/game/static/game/js/level_selection.js
@@ -8,30 +8,30 @@ function setupCoins() {
 
         var minScore = 20;
         var episodeToOpen;
+        var ratios = [];
         for(var j = 0; j < episode.levels.length; j++) {
             var level = episode.levels[j];
-
-            imageStr = getImageStr(level.score, level.maxScore);
-            if(imageStr !== '') {
-                $('.level_image.coin_image[value=' + level.name + ']').attr('src', imageStr);
-            }
-            else {
+            if (level.score === "None"){
                 $('.level_image.coin_image[value=' + level.name + ']').remove();
-                minScore = "None";
                 if(!episodeToOpen) {
                     episodeToOpen =  episode;
                 }
-            }
-
-            if(minScore != "None" && level.score < minScore) {
-                minScore = level.score;
+                ratios.push(-1);
+            } else {
+                var ratio = level.score / level.maxScore;
+                ratios.push(ratio);
+                imageStr = getImageStr(ratio);
+                $('.level_image.coin_image[value=' + level.name + ']').attr('src', imageStr);
             }
         }
 
-        if(minScore !== "None") {
-            $('.episode_image.coin_image[value=' + episode.id + ']').attr('src', getImageStr(minScore))
-        }
-        else {
+        if (ratios.length > 0 && !ratios.includes(-1)){
+            var sum =0;
+            ratios.forEach ((item) => sum += item);
+            var ave_ratio = sum/ratios.length;
+            img = getImageStr(ave_ratio);
+            $('.episode_image.coin_image[value=' + episode.id + ']').attr('src', img)
+        } else {
             $('.episode_image.coin_image[value=' + episode.id + ']').remove();
         }
     }
@@ -39,7 +39,7 @@ function setupCoins() {
     for(var i = 0; i < OTHER_LEVELS.length; i++) {
         var level = OTHER_LEVELS[i];
 
-        imageStr = getImageStr(level.score, level.maxScore);
+        imageStr = getImageStr(level.score / level.maxScore);
         if(imageStr !== '') {
             $('.level_image.coin_image[value=' + level.id + ']').attr('src', imageStr);
         }
@@ -52,21 +52,16 @@ function setupCoins() {
         $('#episode' + episodeToOpen.id).click();
     }
 
-    function getImageStr(score, maxScore) {
+    function getImageStr(fraction) {
         var imageStr = "/static/game/image/coins/coin_";
-        percentage = 100.0 * score / maxScore;
-        if(score == "None") {
-            return "";
-        }
-        else if(percentage >= 99.99999) {
+        if(fraction >= 0.99) {
             return imageStr + 'gold.svg';
         }
-        else if(percentage > 0.5) {
+        else if(fraction > 0.5) {
             return imageStr + 'silver.svg';
         }
-        else if(percentage >= 0.0) {
+        else if(fraction >= 0.0) {
             return imageStr + 'copper.svg';
         }
-        return '';
     }
 }


### PR DESCRIPTION
<!--- Follow the spec: https://www.conventionalcommits.org/en/v1.0.0-beta.3/#specification for the PR title and description -->
<!--- List any breaking changes here with the prefix BREAKING CHANGE: -->

<!--- This template can be modified slightly to the needs of the pull request -->

## Description
Bug fix for #1393 : when an episode is complete, the coin shows in rapid router levels view as broken image.

## How Has This Been Tested?
Added new end to end test for level selection.

## Checklist:
- [  x ] My change requires a change to the documentation.
- [  x ] I have updated the documentation accordingly.
- [  / ] I have linked this PR to a ZenHub Issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1425)
<!-- Reviewable:end -->
