### PR TITLE
fix: 1563-Start Block Is Not Generated At The Top Left Of The Window #1566

### DIFF
--- a/game/static/game/js/blocklyControl.js
+++ b/game/static/game/js/blocklyControl.js
@@ -80,7 +80,8 @@ ocargo.BlocklyControl.prototype.reset = function () {
   // has a start button, if not then create a start button
   if (!wasGameStarted(allBlocks)) {
     let startBlock = this.createBlock("start");
-    startBlock.moveBy(30 + (i % 2) * 200, 30 + Math.floor(i / 2) * 100);
+    // Generate the first block on the (100, 100) position
+    startBlock.moveBy(100, 100);
   }
 
   this.clearIncorrectBlock();


### PR DESCRIPTION
<!--- Follow the spec: https://www.conventionalcommits.org/en/v1.0.0-beta.3/#specification for the PR title and description -->
<!--- List any breaking changes here with the prefix BREAKING CHANGE: -->

<!--- This template can be modified slightly to the needs of the pull request -->

## Description
- This is a fix to this [issue](https://github.com/ocadotechnology/rapid-router/pull/1566).
- It was done by always moving the start block to the fixed position (100, 100) (instead of the previous behavior of generating it in random positions based on the variable `i`, which is a global variable that changes by the for loops inside the code).

## How Has This Been Tested?
[Screencast from 14-01-24 09:19:29.webm](https://github.com/ocadotechnology/rapid-router/assets/68364202/cd22e23f-bf0d-4b42-8b33-9aaa3eb587ef)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1568)
<!-- Reviewable:end -->
