### PR TITLE
fix: add do translation

### DIFF
--- a/game/static/game/js/blockly/msg/js/en-gb.js
+++ b/game/static/game/js/blockly/msg/js/en-gb.js
@@ -465,6 +465,7 @@ Blockly.Msg["COW_CROSSING_TITLE"] = "cows";
 Blockly.Msg["CALL_PROC_TITLE"] = "Call";
 Blockly.Msg["CALL_PROC_TOOLTIP"] = "Calls a procedure";
 Blockly.Msg["DECLARE_PROC_TITLE"] = "Define";
+Blockly.Msg["DECLARE_PROC_SUBTITLE"] = "Do";
 Blockly.Msg["DECLARE_PROC_TOOLTIP"] = "Declares a procedure";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_TITLE"] = "repeat while";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_SUBTITLE"] = "do";

--- a/game/static/game/js/blockly/msg/js/en.js
+++ b/game/static/game/js/blockly/msg/js/en.js
@@ -465,6 +465,7 @@ Blockly.Msg["COW_CROSSING_TITLE"] = "cows";
 Blockly.Msg["CALL_PROC_TITLE"] = "Call";
 Blockly.Msg["CALL_PROC_TOOLTIP"] = "Calls a procedure";
 Blockly.Msg["DECLARE_PROC_TITLE"] = "Define";
+Blockly.Msg["DECLARE_PROC_SUBTITLE"] = "Do";
 Blockly.Msg["DECLARE_PROC_TOOLTIP"] = "Declares a procedure";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_TITLE"] = "repeat while";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_SUBTITLE"] = "do";

--- a/game/static/game/js/blockly/msg/js/fr.js
+++ b/game/static/game/js/blockly/msg/js/fr.js
@@ -465,6 +465,7 @@ Blockly.Msg["COW_CROSSING_TITLE"] = "vaches";
 Blockly.Msg["CALL_PROC_TITLE"] = "Appeler";
 Blockly.Msg["CALL_PROC_TOOLTIP"] = "Appeler une fonction";
 Blockly.Msg["DECLARE_PROC_TITLE"] = "Définir";
+Blockly.Msg["DECLARE_PROC_SUBTITLE"] = "Faire";
 Blockly.Msg["DECLARE_PROC_TOOLTIP"] = "Déclarer une fonction";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_TITLE"] = "répéter tant que";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_SUBTITLE"] = "faire";

--- a/game/static/game/js/blockly/msg/js/hi.js
+++ b/game/static/game/js/blockly/msg/js/hi.js
@@ -465,6 +465,7 @@ Blockly.Msg["COW_CROSSING_TITLE"] = "गायों";
 Blockly.Msg["CALL_PROC_TITLE"] = "पुकारना";
 Blockly.Msg["CALL_PROC_TOOLTIP"] = "एक प्रक्रिया बुलाना";
 Blockly.Msg["DECLARE_PROC_TITLE"] = "परिभाषित करना";
+Blockly.Msg["DECLARE_PROC_SUBTITLE"] = "करो";
 Blockly.Msg["DECLARE_PROC_TOOLTIP"] = "प्रक्रिया की घोषणा करता है";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_TITLE"] = "दोहराएँ जबकि";
 Blockly.Msg["CONTROLS_REPEAT_WHILE_SUBTITLE"] = "करो";

--- a/game/static/game/js/blocklyCustomBlocks.js
+++ b/game/static/game/js/blocklyCustomBlocks.js
@@ -323,7 +323,7 @@ function initCustomBlocksDescription() {
         .appendField(new Blockly.FieldTextInput(name), "NAME");
       this.appendStatementInput("DO")
         .setCheck("Action")
-        .appendField(gettext("Do"));
+        .appendField(Blockly.Msg.DECLARE_PROC_SUBTITLE);
       this.setTooltip(Blockly.Msg.DECLARE_PROC_TOOLTIP);
       this.statementConnection_ = null;
     },


### PR DESCRIPTION
The "do" block was translated as part of the "repeat until / do" and "repeat while / do", so I have taken the translations from there. I have also now added this specific "do" to the translations doc for future languages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1623)
<!-- Reviewable:end -->
