### PR TITLE
fix: update broken python and blockly documentation links

### DIFF
--- a/game/messages.py
+++ b/game/messages.py
@@ -1951,7 +1951,7 @@ def hint_level91():
 
 PYTHON_HINT = (
     "<br /><br />Check our documentation site, to see "
-    "<a href='https://docs.codeforlife.education/rapid-router/python-commands' target='_blank'>the full list of commands</a>."
+    "<a href='https://code-for-life.gitbook.io/rapid-router/rapid-router-python-commands' target='_blank'>the full list of commands</a>."
     "<br /><br />To learn more about Python in general, check this "
     "<a href='https://wiki.python.org/moin/BeginnersGuide' target='_blank'>Beginner's Guide to Python</a>."
 )

--- a/game/templates/game/level_selection.html
+++ b/game/templates/game/level_selection.html
@@ -73,7 +73,7 @@
         <div class="panel-intro">
             <h4>Blockly levels</h4>
             The first set of levels use Blockly to slowly introduce you to Python. You can read more about Blockly
-            <a href="https://docs.codeforlife.education/rapid-router/blockly-guide" target="_blank">here</a>.
+            <a href="https://code-for-life.gitbook.io/rapid-router/blockly-guide" target="_blank">here</a>.
         </div>
         {% for episode in blocklyEpisodes %}
         <div class="panel">
@@ -126,7 +126,7 @@
         <div class="panel-intro">
             <h4>Python levels</h4>
             The next set of levels introduce you to coding directly with Python. You can read more about Python
-            <a href="https://docs.codeforlife.education/rapid-router/python-guide" target="_blank">here</a>.
+            <a href="https://code-for-life.gitbook.io/rapid-router/python-guide" target="_blank">here</a>.
         </div>
         {% for episode in oldPythonEpisodes %}
         <div class="panel">


### PR DESCRIPTION
The following links have been fixed:
- the link in some Python Den levels' hints (i.e. Level 42's hint) to the full list of Python commands
- the "You can read more about Blockly here" link on the Rapid Router level selection page 
- the "You can read more about Python here" link on the Rapid Router level selection page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1721)
<!-- Reviewable:end -->
