### PR TITLE
fix: character change does not persist after save.

### DIFF
--- a/game/static/game/js/level_editor.js
+++ b/game/static/game/js/level_editor.js
@@ -2556,6 +2556,17 @@ ocargo.LevelEditor = function(levelId) {
     function restoreState(state) {
         console.log("restoring state");
 
+        // Get character id from saved character name
+        var characterName = state.character_name;
+        if (characterName) {
+            var characterId = null;
+            for (var id in CHARACTERS) {
+                if (characterName == CHARACTERS[id].name) {
+                    characterId = id;
+                    break;
+                }
+            }
+        }
         clear();
 
         // Load node data
@@ -2585,7 +2596,7 @@ ocargo.LevelEditor = function(levelId) {
         }
 
         // Load in character
-        $('#character_select').val(state.character);
+        $('#character_select').val(characterId);
         $('#character_select').change();
 
         drawAll();


### PR DESCRIPTION
<!--- Follow the spec: https://www.conventionalcommits.org/en/v1.0.0-beta.3/#specification for the PR title and description -->
<!--- List any breaking changes here with the prefix BREAKING CHANGE: -->

<!--- This template can be modified slightly to the needs of the pull request -->

## Description
<!--- Describe your changes -->
I fixed the issue where a character change in the level editor would not appear in the character tab and would default to the van option. 
This happened because the restoreState function was trying to get the character id from saved level, but it was the character name that was saved not the id. I changed this by getting the character id from the saved character name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested this using pytest and all the tests passed. 
I also tested it by creating new levels in the level editor and checking if the change is there.

## Checklist:
<!--- These can be used to show you've met the issue criteria, or similar. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have linked this PR to a ZenHub Issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/rapid-router/1749)
<!-- Reviewable:end -->
